### PR TITLE
Feat cambiar apodo & actualizar descripción

### DIFF
--- a/apps/backend/__tests__/e2e/escalador.e2e.test.js
+++ b/apps/backend/__tests__/e2e/escalador.e2e.test.js
@@ -16,6 +16,10 @@ describe('E2E: Escalador', () => {
   let rocodromoTest;
   let tokenSuscripcion;
   let escaladorValidacion;
+  let escaladorDescripcion;
+  let escaladorCambioApodo;
+  let tokenDescripcion;
+  let tokenCambioApodo;
 
   beforeAll(async () => {
     // Crear escalador de prueba para suscripción
@@ -42,6 +46,29 @@ describe('E2E: Escalador', () => {
       contrasena: 'hashedPassword123',
       apodo: 'ValidarApodo',
     });
+
+    escaladorDescripcion = await db.Escalador.create({
+      correo: 'descripcion@test.com',
+      contrasena: 'hashedPassword123',
+      apodo: 'DescripcionTester',
+      descripcion: null,
+    });
+
+    tokenDescripcion = tokenService.crear({
+      correo: escaladorDescripcion.correo,
+      apodo: escaladorDescripcion.apodo,
+    });
+
+    escaladorCambioApodo = await db.Escalador.create({
+      correo: 'cambio-apodo@test.com',
+      contrasena: 'hashedPassword123',
+      apodo: 'ApodoOriginal',
+    });
+
+    tokenCambioApodo = tokenService.crear({
+      correo: escaladorCambioApodo.correo,
+      apodo: escaladorCambioApodo.apodo,
+    });
   });
 
   afterAll(async () => {
@@ -59,6 +86,10 @@ describe('E2E: Escalador', () => {
     }
     if (escaladorSuscripcion) await escaladorSuscripcion.destroy();
     if (escaladorValidacion) await escaladorValidacion.destroy();
+    if (escaladorDescripcion) await escaladorDescripcion.destroy();
+    if (escaladorCambioApodo) {
+      await db.Escalador.destroy({ where: { correo: escaladorCambioApodo.correo } });
+    }
     if (rocodromoTest) await rocodromoTest.destroy();
     
     await db.sequelize.close();
@@ -368,6 +399,91 @@ describe('E2E: Escalador', () => {
       expect(response.body).toHaveProperty('status', 'invalid_request');
       const fields = response.body.errors.map((e) => e.field);
       expect(fields).toContain('correo');
+    });
+  });
+
+  describe('Actualizar descripcion', () => {
+    it('deberia actualizar la descripcion del escalador autenticado', async () => {
+      const response = await request(app)
+        .put('/escaladores/actualizarDescripcion')
+        .set('Authorization', `Bearer ${tokenDescripcion}`)
+        .send({ descripcion: 'Nueva descripcion de perfil' })
+        .expect(200);
+
+      expect(response.body).toHaveProperty('id');
+      expect(response.body).toHaveProperty('correo', escaladorDescripcion.correo);
+      expect(response.body).toHaveProperty('apodo', escaladorDescripcion.apodo);
+      expect(response.body).toHaveProperty('descripcion', 'Nueva descripcion de perfil');
+
+      const escaladorActualizado = await db.Escalador.findByPk(escaladorDescripcion.id);
+      expect(escaladorActualizado.descripcion).toBe('Nueva descripcion de perfil');
+    });
+
+    it('deberia retornar 401 si no se proporciona token', async () => {
+      const response = await request(app)
+        .put('/escaladores/actualizarDescripcion')
+        .send({ descripcion: 'Texto' })
+        .expect(401);
+
+      expect(response.body).toHaveProperty('error');
+      expect(response.body).toHaveProperty('code', 'AUTH_TOKEN_MISSING');
+    });
+
+    it('deberia retornar 422 si la descripcion es muy larga', async () => {
+      const response = await request(app)
+        .put('/escaladores/actualizarDescripcion')
+        .set('Authorization', `Bearer ${tokenDescripcion}`)
+        .send({ descripcion: 'a'.repeat(256) })
+        .expect(422);
+
+      expect(response.body).toHaveProperty('status', 'invalid_request');
+      const fields = response.body.errors.map((e) => e.field);
+      expect(fields).toContain('descripcion');
+    });
+  });
+
+  describe('Cambiar apodo', () => {
+    it('deberia actualizar el apodo y devolver un nuevo token', async () => {
+      const response = await request(app)
+        .put('/escaladores/cambiarApodo')
+        .set('Authorization', `Bearer ${tokenCambioApodo}`)
+        .send({ apodo: 'ApodoActualizado' })
+        .expect(200);
+
+      expect(response.body).toHaveProperty('apodo', 'ApodoActualizado');
+      expect(response.body).toHaveProperty('correo', escaladorCambioApodo.correo);
+      expect(response.body).toHaveProperty('token');
+      expect(typeof response.body.token).toBe('string');
+
+      const decoded = tokenService.verificar(response.body.token);
+      expect(decoded.apodo).toBe('ApodoActualizado');
+
+      const escaladorActualizado = await db.Escalador.findOne({
+        where: { correo: escaladorCambioApodo.correo },
+      });
+      expect(escaladorActualizado.apodo).toBe('ApodoActualizado');
+    });
+
+    it('deberia retornar 422 con apodo invalido', async () => {
+      const response = await request(app)
+        .put('/escaladores/cambiarApodo')
+        .set('Authorization', `Bearer ${tokenCambioApodo}`)
+        .send({ apodo: '!!!invalid!!!' })
+        .expect(422);
+
+      expect(response.body).toHaveProperty('status', 'invalid_request');
+      const fields = response.body.errors.map((e) => e.field);
+      expect(fields).toContain('apodo');
+    });
+
+    it('deberia retornar 401 si no se proporciona token', async () => {
+      const response = await request(app)
+        .put('/escaladores/cambiarApodo')
+        .send({ apodo: 'OtroApodo' })
+        .expect(401);
+
+      expect(response.body).toHaveProperty('error');
+      expect(response.body).toHaveProperty('code', 'AUTH_TOKEN_MISSING');
     });
   });
 });

--- a/apps/backend/__tests__/e2e/escalador.e2e.test.js
+++ b/apps/backend/__tests__/e2e/escalador.e2e.test.js
@@ -15,6 +15,7 @@ describe('E2E: Escalador', () => {
   let escaladorSuscripcion;
   let rocodromoTest;
   let tokenSuscripcion;
+  let escaladorValidacion;
 
   beforeAll(async () => {
     // Crear escalador de prueba para suscripción
@@ -35,6 +36,12 @@ describe('E2E: Escalador', () => {
       correo: escaladorSuscripcion.correo, 
       apodo: escaladorSuscripcion.apodo 
     });
+
+    escaladorValidacion = await db.Escalador.create({
+      correo: 'validacion@test.com',
+      contrasena: 'hashedPassword123',
+      apodo: 'ValidarApodo',
+    });
   });
 
   afterAll(async () => {
@@ -51,6 +58,7 @@ describe('E2E: Escalador', () => {
       }
     }
     if (escaladorSuscripcion) await escaladorSuscripcion.destroy();
+    if (escaladorValidacion) await escaladorValidacion.destroy();
     if (rocodromoTest) await rocodromoTest.destroy();
     
     await db.sequelize.close();
@@ -302,6 +310,64 @@ describe('E2E: Escalador', () => {
       expect(response.body).toHaveProperty('error');
       expect(response.body).toHaveProperty('code', 'AUTH_TOKEN_MISSING');
       expect(response.body.error).toContain('Acceso denegado');
+    });
+  });
+
+  describe('Validar apodo', () => {
+    it('deberia devolver disponible false si el apodo ya existe (case-insensitive)', async () => {
+      const response = await request(app)
+        .get('/escaladores/validarApodo/validarapodo')
+        .expect(200);
+
+      expect(response.body).toEqual({ disponible: false });
+    });
+
+    it('deberia devolver disponible true si el apodo no existe', async () => {
+      const response = await request(app)
+        .get('/escaladores/validarApodo/ApodoNuevo123')
+        .expect(200);
+
+      expect(response.body).toEqual({ disponible: true });
+    });
+
+    it('deberia retornar 422 con apodo invalido', async () => {
+      const response = await request(app)
+        .get('/escaladores/validarApodo/!!!invalid!!!')
+        .expect(422);
+
+      expect(response.body).toHaveProperty('status', 'invalid_request');
+      const fields = response.body.errors.map((e) => e.field);
+      expect(fields).toContain('apodo');
+    });
+  });
+
+  describe('Validar correo', () => {
+    it('deberia devolver disponible false si el correo ya existe', async () => {
+      const correo = encodeURIComponent('validacion@test.com');
+      const response = await request(app)
+        .get(`/escaladores/validarCorreo/${correo}`)
+        .expect(200);
+
+      expect(response.body).toEqual({ disponible: false });
+    });
+
+    it('deberia devolver disponible true si el correo no existe', async () => {
+      const correo = encodeURIComponent('nuevo_correo@test.com');
+      const response = await request(app)
+        .get(`/escaladores/validarCorreo/${correo}`)
+        .expect(200);
+
+      expect(response.body).toEqual({ disponible: true });
+    });
+
+    it('deberia retornar 422 con correo invalido', async () => {
+      const response = await request(app)
+        .get('/escaladores/validarCorreo/no-es-email')
+        .expect(422);
+
+      expect(response.body).toHaveProperty('status', 'invalid_request');
+      const fields = response.body.errors.map((e) => e.field);
+      expect(fields).toContain('correo');
     });
   });
 });

--- a/apps/backend/__tests__/unit/application/escaladores/actualizarDescripcionEscalador.test.js
+++ b/apps/backend/__tests__/unit/application/escaladores/actualizarDescripcionEscalador.test.js
@@ -1,0 +1,57 @@
+import { jest } from '@jest/globals';
+import ActualizarDescripcionEscalador from '../../../../src/application/escaladores/actualizarDescripcionEscalador.js';
+import { InternalServerError, NotFoundError } from '../../../../src/domain/sharedObjects/AppError.js';
+
+describe('actualizarDescripcionEscaladorUseCase', () => {
+  it('deberia devolver el perfil actualizado', async () => {
+    const mockRepository = {
+      actualizarDescripcion: jest.fn().mockResolvedValue({
+        id: 7,
+        correo: 'test@correo.com',
+        apodo: 'Tester',
+        descripcion: 'Nueva descripcion',
+        idFotoPerfil: 2,
+      }),
+    };
+
+    const useCase = new ActualizarDescripcionEscalador(mockRepository);
+    const resultado = await useCase.execute({
+      apodo: 'Tester',
+      descripcion: 'Nueva descripcion',
+    });
+
+    expect(mockRepository.actualizarDescripcion).toHaveBeenCalledWith(
+      'Tester',
+      'Nueva descripcion'
+    );
+    expect(resultado).toEqual({
+      id: 7,
+      correo: 'test@correo.com',
+      apodo: 'Tester',
+      descripcion: 'Nueva descripcion',
+      idFotoPerfil: 2,
+    });
+  });
+
+  it('deberia lanzar NotFoundError si no existe el escalador', async () => {
+    const mockRepository = {
+      actualizarDescripcion: jest.fn().mockResolvedValue(null),
+    };
+    const useCase = new ActualizarDescripcionEscalador(mockRepository);
+
+    await expect(
+      useCase.execute({ apodo: 'NoExiste', descripcion: 'Texto' })
+    ).rejects.toBeInstanceOf(NotFoundError);
+  });
+
+  it('deberia lanzar InternalServerError si falla el repositorio', async () => {
+    const mockRepository = {
+      actualizarDescripcion: jest.fn().mockRejectedValue(new Error('db fail')),
+    };
+    const useCase = new ActualizarDescripcionEscalador(mockRepository);
+
+    await expect(
+      useCase.execute({ apodo: 'Tester', descripcion: 'Texto' })
+    ).rejects.toBeInstanceOf(InternalServerError);
+  });
+});

--- a/apps/backend/__tests__/unit/application/escaladores/cambiarApodoEscalador.test.js
+++ b/apps/backend/__tests__/unit/application/escaladores/cambiarApodoEscalador.test.js
@@ -1,0 +1,81 @@
+import { jest } from '@jest/globals';
+import CambiarApodoEscalador from '../../../../src/application/escaladores/cambiarApodoEscalador.js';
+import { InternalServerError, NotFoundError } from '../../../../src/domain/sharedObjects/AppError.js';
+
+describe('cambiarApodoEscaladorUseCase', () => {
+  it('deberia devolver perfil actualizado y token', async () => {
+    const mockRepository = {
+      actualizarApodo: jest.fn().mockResolvedValue({
+        id: 3,
+        correo: 'test@correo.com',
+        apodo: 'NuevoApodo',
+        descripcion: 'Bio',
+        idFotoPerfil: 1,
+      }),
+    };
+    const mockTokenService = {
+      crear: jest.fn().mockReturnValue('nuevo_token'),
+    };
+
+    const useCase = new CambiarApodoEscalador(mockRepository, mockTokenService);
+    const resultado = await useCase.execute({
+      apodoActual: 'ViejoApodo',
+      nuevoApodo: 'NuevoApodo',
+      usuario: { correo: 'test@correo.com', apodo: 'ViejoApodo', rol: 'Escalador' },
+    });
+
+    expect(mockRepository.actualizarApodo).toHaveBeenCalledWith(
+      'ViejoApodo',
+      'NuevoApodo'
+    );
+    expect(mockTokenService.crear).toHaveBeenCalledWith({
+      correo: 'test@correo.com',
+      apodo: 'NuevoApodo',
+      rol: 'Escalador',
+    });
+    expect(resultado).toEqual({
+      id: 3,
+      correo: 'test@correo.com',
+      apodo: 'NuevoApodo',
+      descripcion: 'Bio',
+      idFotoPerfil: 1,
+      token: 'nuevo_token',
+    });
+  });
+
+  it('deberia lanzar NotFoundError si no existe el escalador', async () => {
+    const mockRepository = {
+      actualizarApodo: jest.fn().mockResolvedValue(null),
+    };
+    const mockTokenService = {
+      crear: jest.fn(),
+    };
+    const useCase = new CambiarApodoEscalador(mockRepository, mockTokenService);
+
+    await expect(
+      useCase.execute({
+        apodoActual: 'NoExiste',
+        nuevoApodo: 'NuevoApodo',
+        usuario: { correo: 'test@correo.com', apodo: 'NoExiste' },
+      })
+    ).rejects.toBeInstanceOf(NotFoundError);
+  });
+
+  it('deberia lanzar InternalServerError si falla el repositorio', async () => {
+    const mockRepository = {
+      actualizarApodo: jest.fn().mockRejectedValue(new Error('db fail')),
+    };
+    const mockTokenService = {
+      crear: jest.fn(),
+    };
+    const useCase = new CambiarApodoEscalador(mockRepository, mockTokenService);
+
+    await expect(
+      useCase.execute({
+        apodoActual: 'ViejoApodo',
+        nuevoApodo: 'NuevoApodo',
+        usuario: { correo: 'test@correo.com', apodo: 'ViejoApodo' },
+      })
+    ).rejects.toBeInstanceOf(InternalServerError);
+  });
+});

--- a/apps/backend/__tests__/unit/application/escaladores/validarApodoEscalador.test.js
+++ b/apps/backend/__tests__/unit/application/escaladores/validarApodoEscalador.test.js
@@ -1,0 +1,37 @@
+import { jest } from '@jest/globals';
+import ValidarApodoEscalador from '../../../../src/application/escaladores/validarApodoEscalador.js';
+import { InternalServerError } from '../../../../src/domain/sharedObjects/AppError.js';
+
+describe('validarApodoEscaladorUseCase', () => {
+  it('deberia devolver disponible true cuando no existe el apodo', async () => {
+    const mockRepository = {
+      encontrarPorApodoInsensitive: jest.fn().mockResolvedValue(null),
+    };
+    const useCase = new ValidarApodoEscalador(mockRepository);
+
+    const resultado = await useCase.execute('NuevoApodo');
+
+    expect(mockRepository.encontrarPorApodoInsensitive).toHaveBeenCalledWith('nuevoapodo');
+    expect(resultado).toEqual({ disponible: true });
+  });
+
+  it('deberia devolver disponible false cuando el apodo ya existe', async () => {
+    const mockRepository = {
+      encontrarPorApodoInsensitive: jest.fn().mockResolvedValue({ id: 1, apodo: 'Test' }),
+    };
+    const useCase = new ValidarApodoEscalador(mockRepository);
+
+    const resultado = await useCase.execute('Test');
+
+    expect(resultado).toEqual({ disponible: false });
+  });
+
+  it('deberia lanzar InternalServerError si falla el repositorio', async () => {
+    const mockRepository = {
+      encontrarPorApodoInsensitive: jest.fn().mockRejectedValue(new Error('db fail')),
+    };
+    const useCase = new ValidarApodoEscalador(mockRepository);
+
+    await expect(useCase.execute('Test')).rejects.toBeInstanceOf(InternalServerError);
+  });
+});

--- a/apps/backend/__tests__/unit/application/escaladores/validarCorreoEscalador.test.js
+++ b/apps/backend/__tests__/unit/application/escaladores/validarCorreoEscalador.test.js
@@ -1,0 +1,37 @@
+import { jest } from '@jest/globals';
+import ValidarCorreoEscalador from '../../../../src/application/escaladores/validarCorreoEscalador.js';
+import { InternalServerError } from '../../../../src/domain/sharedObjects/AppError.js';
+
+describe('validarCorreoEscaladorUseCase', () => {
+  it('deberia devolver disponible true cuando no existe el correo', async () => {
+    const mockRepository = {
+      encontrarPorCorreo: jest.fn().mockResolvedValue(null),
+    };
+    const useCase = new ValidarCorreoEscalador(mockRepository);
+
+    const resultado = await useCase.execute('nuevo@correo.com');
+
+    expect(mockRepository.encontrarPorCorreo).toHaveBeenCalledWith('nuevo@correo.com');
+    expect(resultado).toEqual({ disponible: true });
+  });
+
+  it('deberia devolver disponible false cuando el correo ya existe', async () => {
+    const mockRepository = {
+      encontrarPorCorreo: jest.fn().mockResolvedValue({ id: 1, correo: 'test@correo.com' }),
+    };
+    const useCase = new ValidarCorreoEscalador(mockRepository);
+
+    const resultado = await useCase.execute('test@correo.com');
+
+    expect(resultado).toEqual({ disponible: false });
+  });
+
+  it('deberia lanzar InternalServerError si falla el repositorio', async () => {
+    const mockRepository = {
+      encontrarPorCorreo: jest.fn().mockRejectedValue(new Error('db fail')),
+    };
+    const useCase = new ValidarCorreoEscalador(mockRepository);
+
+    await expect(useCase.execute('test@correo.com')).rejects.toBeInstanceOf(InternalServerError);
+  });
+});

--- a/apps/backend/src/application/escaladores/actualizarDescripcionEscalador.js
+++ b/apps/backend/src/application/escaladores/actualizarDescripcionEscalador.js
@@ -1,0 +1,44 @@
+import {
+  AppError,
+  InternalServerError,
+  NotFoundError,
+} from '../../domain/sharedObjects/AppError.js';
+
+class ActualizarDescripcionEscalador {
+  constructor(escaladorRepository) {
+    this.escaladorRepository = escaladorRepository;
+  }
+
+  async execute({ apodo, descripcion }) {
+    try {
+      const escalador = await this.escaladorRepository.actualizarDescripcion(
+        apodo,
+        descripcion
+      );
+
+      if (!escalador) {
+        throw new NotFoundError('Escalador no encontrado', 'ESCALADOR_NOT_FOUND');
+      }
+
+      return {
+        id: escalador.id,
+        correo: escalador.correo,
+        apodo: escalador.apodo,
+        descripcion: escalador.descripcion,
+        idFotoPerfil: escalador.idFotoPerfil,
+      };
+    } catch (error) {
+      if (error instanceof AppError) {
+        throw error;
+      }
+
+      throw new InternalServerError(
+        'Error al actualizar la descripcion del escalador',
+        'ESCALADOR_DESCRIPCION_UPDATE_FAILED',
+        error
+      );
+    }
+  }
+}
+
+export default ActualizarDescripcionEscalador;

--- a/apps/backend/src/application/escaladores/cambiarApodoEscalador.js
+++ b/apps/backend/src/application/escaladores/cambiarApodoEscalador.js
@@ -1,0 +1,52 @@
+import {
+  AppError,
+  InternalServerError,
+  NotFoundError,
+} from '../../domain/sharedObjects/AppError.js';
+
+class CambiarApodoEscalador {
+  constructor(escaladorRepository, tokenService) {
+    this.escaladorRepository = escaladorRepository;
+    this.tokenService = tokenService;
+  }
+
+  async execute({ apodoActual, nuevoApodo, usuario }) {
+    try {
+      const escalador = await this.escaladorRepository.actualizarApodo(
+        apodoActual,
+        nuevoApodo
+      );
+
+      if (!escalador) {
+        throw new NotFoundError('Escalador no encontrado', 'ESCALADOR_NOT_FOUND');
+      }
+
+      const payload = {
+        ...usuario,
+        apodo: escalador.apodo,
+      };
+      const token = this.tokenService.crear(payload);
+
+      return {
+        id: escalador.id,
+        correo: escalador.correo,
+        apodo: escalador.apodo,
+        descripcion: escalador.descripcion,
+        idFotoPerfil: escalador.idFotoPerfil,
+        token,
+      };
+    } catch (error) {
+      if (error instanceof AppError) {
+        throw error;
+      }
+
+      throw new InternalServerError(
+        'Error al cambiar el apodo del escalador',
+        'ESCALADOR_APODO_UPDATE_FAILED',
+        error
+      );
+    }
+  }
+}
+
+export default CambiarApodoEscalador;

--- a/apps/backend/src/application/escaladores/cambiarApodoEscalador.js
+++ b/apps/backend/src/application/escaladores/cambiarApodoEscalador.js
@@ -21,9 +21,12 @@ class CambiarApodoEscalador {
         throw new NotFoundError('Escalador no encontrado', 'ESCALADOR_NOT_FOUND');
       }
 
+      usuario.apodo = escalador.apodo; // Actualiza el apodo en el payload del token
       const payload = {
-        ...usuario,
-        apodo: escalador.apodo,
+        apodo: usuario.apodo,
+        correo: usuario.correo,
+        rol: usuario.rol,
+        ...(usuario.rol === 'Gestor' ? { rocodromosGestionados: usuario.rocodromosGestionados } : {})
       };
       const token = this.tokenService.crear(payload);
 

--- a/apps/backend/src/application/escaladores/validarApodoEscalador.js
+++ b/apps/backend/src/application/escaladores/validarApodoEscalador.js
@@ -1,0 +1,31 @@
+import { AppError, InternalServerError } from '../../domain/sharedObjects/AppError.js';
+
+class ValidarApodoEscalador {
+  constructor(escaladorRepository) {
+    this.escaladorRepository = escaladorRepository;
+  }
+
+  async execute(apodo) {
+    try {
+      const apodoNormalizado = apodo.toLowerCase();
+      const escalador =
+        await this.escaladorRepository.encontrarPorApodoInsensitive(
+          apodoNormalizado
+        );
+
+      return { disponible: !escalador };
+    } catch (error) {
+      if (error instanceof AppError) {
+        throw error;
+      }
+
+      throw new InternalServerError(
+        'Error al validar apodo del escalador',
+        'ESCALADOR_APODO_VALIDATE_FAILED',
+        error
+      );
+    }
+  }
+}
+
+export default ValidarApodoEscalador;

--- a/apps/backend/src/application/escaladores/validarCorreoEscalador.js
+++ b/apps/backend/src/application/escaladores/validarCorreoEscalador.js
@@ -1,0 +1,27 @@
+import { AppError, InternalServerError } from '../../domain/sharedObjects/AppError.js';
+
+class ValidarCorreoEscalador {
+  constructor(escaladorRepository) {
+    this.escaladorRepository = escaladorRepository;
+  }
+
+  async execute(correo) {
+    try {
+      const escalador = await this.escaladorRepository.encontrarPorCorreo(correo);
+
+      return { disponible: !escalador };
+    } catch (error) {
+      if (error instanceof AppError) {
+        throw error;
+      }
+
+      throw new InternalServerError(
+        'Error al validar correo del escalador',
+        'ESCALADOR_CORREO_VALIDATE_FAILED',
+        error
+      );
+    }
+  }
+}
+
+export default ValidarCorreoEscalador;

--- a/apps/backend/src/domain/escaladores/escaladorRepository.js
+++ b/apps/backend/src/domain/escaladores/escaladorRepository.js
@@ -12,6 +12,10 @@ class EscaladorRepository {
     throw new Error('Método "encontrarPorApodo" no implementado');
   }
 
+  async encontrarPorApodoInsensitive(apodo) {
+    throw new Error('Método "encontrarPorApodoInsensitive" no implementado');
+  }
+
   async suscribirse(escaladorApodo, rocodromo) {
     throw new Error('Método "suscribirse" no implementado');
   }

--- a/apps/backend/src/domain/escaladores/escaladorRepository.js
+++ b/apps/backend/src/domain/escaladores/escaladorRepository.js
@@ -39,5 +39,13 @@ class EscaladorRepository {
   async actualizarFotoPerfilId(escaladorApodo, idFotoPerfil) {
     throw new Error('Método "actualizarFotoPerfilId" no implementado');
   }
+
+  async actualizarDescripcion(apodo, descripcion) {
+    throw new Error('Método "actualizarDescripcion" no implementado');
+  }
+
+  async actualizarApodo(apodoActual, nuevoApodo) {
+    throw new Error('Método "actualizarApodo" no implementado');
+  }
 }
 export default EscaladorRepository;

--- a/apps/backend/src/infrastructure/container.js
+++ b/apps/backend/src/infrastructure/container.js
@@ -28,6 +28,8 @@ import CrearFotoPerfil from '../application/escaladores/crearFotoPerfil.js';
 import ObtenerFotosPerfil from '../application/escaladores/obtenerFotosPerfil.js';
 import ObtenerFotoPerfil from '../application/escaladores/obtenerFotoPerfil.js';
 import ActualizarFotoPerfilEscalador from '../application/escaladores/actualizarFotoPerfilEscalador.js';
+import ValidarApodoEscalador from '../application/escaladores/validarApodoEscalador.js';
+import ValidarCorreoEscalador from '../application/escaladores/validarCorreoEscalador.js';
 
 import CrearPista from '../application/pistas/crearPista.js';
 import ActualizarPista from '../application/pistas/actualizarPista.js';
@@ -99,6 +101,8 @@ async function inicializarContainer() {
     escaladorRepository,
     fotosPerfilRepository
   );
+  const validarApodoUseCase = new ValidarApodoEscalador(escaladorRepository);
+  const validarCorreoUseCase = new ValidarCorreoEscalador(escaladorRepository);
 
   const crearPistaUseCase = new CrearPista(
     pistaRepository,
@@ -154,6 +158,8 @@ async function inicializarContainer() {
     obtenerFotosPerfil: obtenerFotosPerfilUseCase,
     obtenerFotoPerfil: obtenerFotoPerfilUseCase,
     actualizarFotoPerfil: actualizarFotoPerfilUseCase,
+    validarApodo: validarApodoUseCase,
+    validarCorreo: validarCorreoUseCase,
   };
   const pistaUseCases = {
     crear: crearPistaUseCase,

--- a/apps/backend/src/infrastructure/container.js
+++ b/apps/backend/src/infrastructure/container.js
@@ -30,6 +30,8 @@ import ObtenerFotoPerfil from '../application/escaladores/obtenerFotoPerfil.js';
 import ActualizarFotoPerfilEscalador from '../application/escaladores/actualizarFotoPerfilEscalador.js';
 import ValidarApodoEscalador from '../application/escaladores/validarApodoEscalador.js';
 import ValidarCorreoEscalador from '../application/escaladores/validarCorreoEscalador.js';
+import ActualizarDescripcionEscalador from '../application/escaladores/actualizarDescripcionEscalador.js';
+import CambiarApodoEscalador from '../application/escaladores/cambiarApodoEscalador.js';
 
 import CrearPista from '../application/pistas/crearPista.js';
 import ActualizarPista from '../application/pistas/actualizarPista.js';
@@ -103,6 +105,13 @@ async function inicializarContainer() {
   );
   const validarApodoUseCase = new ValidarApodoEscalador(escaladorRepository);
   const validarCorreoUseCase = new ValidarCorreoEscalador(escaladorRepository);
+  const actualizarDescripcionUseCase = new ActualizarDescripcionEscalador(
+    escaladorRepository
+  );
+  const cambiarApodoUseCase = new CambiarApodoEscalador(
+    escaladorRepository,
+    tokenService
+  );
 
   const crearPistaUseCase = new CrearPista(
     pistaRepository,
@@ -160,6 +169,8 @@ async function inicializarContainer() {
     actualizarFotoPerfil: actualizarFotoPerfilUseCase,
     validarApodo: validarApodoUseCase,
     validarCorreo: validarCorreoUseCase,
+    actualizarDescripcion: actualizarDescripcionUseCase,
+    cambiarApodo: cambiarApodoUseCase,
   };
   const pistaUseCases = {
     crear: crearPistaUseCase,

--- a/apps/backend/src/infrastructure/repositories/escaladorRepositoryPostgres.js
+++ b/apps/backend/src/infrastructure/repositories/escaladorRepositoryPostgres.js
@@ -243,6 +243,52 @@ class EscaladorRepositoryPostgres extends escaladorRepository {
       });
     }
   }
+
+  async actualizarDescripcion(apodo, descripcion) {
+    try {
+      const escaladorModel = await this.EscaladorModel.findOne({
+        where: { apodo },
+      });
+
+      if (!escaladorModel) {
+        return null;
+      }
+
+      escaladorModel.descripcion = descripcion;
+      await escaladorModel.save();
+
+      return this._toDomain(escaladorModel);
+    } catch (error) {
+      throw mapRepositoryError(error, {
+        fallbackMessage: 'Error al actualizar la descripcion del escalador',
+        internalCode: 'ESCALADOR_DESCRIPTION_UPDATE_DB_FAILED',
+      });
+    }
+  }
+
+  async actualizarApodo(apodoActual, nuevoApodo) {
+    try {
+      const escaladorModel = await this.EscaladorModel.findOne({
+        where: { apodo: apodoActual },
+      });
+
+      if (!escaladorModel) {
+        return null;
+      }
+
+      escaladorModel.apodo = nuevoApodo;
+      await escaladorModel.save();
+
+      return this._toDomain(escaladorModel);
+    } catch (error) {
+      throw mapRepositoryError(error, {
+        fallbackMessage: 'Error al actualizar el apodo del escalador',
+        conflictMessage: 'El apodo ya está registrado',
+        conflictCode: 'ESCALADOR_APODO_DUPLICADO_DB',
+        internalCode: 'ESCALADOR_NICKNAME_UPDATE_DB_FAILED',
+      });
+    }
+  }
 }
 
 export default EscaladorRepositoryPostgres;

--- a/apps/backend/src/infrastructure/repositories/escaladorRepositoryPostgres.js
+++ b/apps/backend/src/infrastructure/repositories/escaladorRepositoryPostgres.js
@@ -82,7 +82,7 @@ class EscaladorRepositoryPostgres extends escaladorRepository {
   async encontrarPorApodoInsensitive(apodo) {
     try {
       const escaladorModel = await this.EscaladorModel.findOne({
-        where: where(fn('lower', col('apodo')), apodo.toLowerCase()),
+        where: where(fn('lower', col('Apodo')), apodo.toLowerCase()),
       });
       return this._toDomain(escaladorModel);
     } catch (error) {

--- a/apps/backend/src/infrastructure/repositories/escaladorRepositoryPostgres.js
+++ b/apps/backend/src/infrastructure/repositories/escaladorRepositoryPostgres.js
@@ -1,3 +1,4 @@
+import { col, fn, where } from 'sequelize';
 import escaladorRepository from '../../domain/escaladores/escaladorRepository.js';
 import Escalador from '../../domain/escaladores/Escalador.js';
 import Rocodromo from '../../domain/rocodromos/Rocodromo.js';
@@ -74,6 +75,20 @@ class EscaladorRepositoryPostgres extends escaladorRepository {
       throw mapRepositoryError(error, {
         fallbackMessage: 'Error al buscar escalador por apodo',
         internalCode: 'ESCALADOR_FIND_BY_NICKNAME_FAILED',
+      });
+    }
+  }
+
+  async encontrarPorApodoInsensitive(apodo) {
+    try {
+      const escaladorModel = await this.EscaladorModel.findOne({
+        where: where(fn('lower', col('apodo')), apodo.toLowerCase()),
+      });
+      return this._toDomain(escaladorModel);
+    } catch (error) {
+      throw mapRepositoryError(error, {
+        fallbackMessage: 'Error al buscar escalador por apodo (insensible)',
+        internalCode: 'ESCALADOR_FIND_BY_NICKNAME_INSENSITIVE_FAILED',
       });
     }
   }

--- a/apps/backend/src/interfaces/http/controllers/escaladorController.js
+++ b/apps/backend/src/interfaces/http/controllers/escaladorController.js
@@ -209,6 +209,39 @@ class EscaladorController {
       return next(error);
     }
   }
+
+  async actualizarDescripcion(req, res, next) {
+    try {
+      const { descripcion } = req.body;
+      const apodo = req.user.apodo;
+
+      const resultado = await this.useCases.actualizarDescripcion.execute({
+        apodo,
+        descripcion,
+      });
+
+      res.status(200).json(resultado);
+    } catch (error) {
+      return next(error);
+    }
+  }
+
+  async cambiarApodo(req, res, next) {
+    try {
+      const { apodo } = req.body;
+      const apodoActual = req.user.apodo;
+
+      const resultado = await this.useCases.cambiarApodo.execute({
+        apodoActual,
+        nuevoApodo: apodo,
+        usuario: req.user,
+      });
+
+      res.status(200).json(resultado);
+    } catch (error) {
+      return next(error);
+    }
+  }
 }
 
 export default EscaladorController;

--- a/apps/backend/src/interfaces/http/controllers/escaladorController.js
+++ b/apps/backend/src/interfaces/http/controllers/escaladorController.js
@@ -187,6 +187,28 @@ class EscaladorController {
       return next(error);
     }
   }
+
+  async validarApodo(req, res, next) {
+    try {
+      const { apodo } = req.params;
+      const resultado = await this.useCases.validarApodo.execute(apodo);
+
+      res.status(200).json(resultado);
+    } catch (error) {
+      return next(error);
+    }
+  }
+
+  async validarCorreo(req, res, next) {
+    try {
+      const { correo } = req.params;
+      const resultado = await this.useCases.validarCorreo.execute(correo);
+
+      res.status(200).json(resultado);
+    } catch (error) {
+      return next(error);
+    }
+  }
 }
 
 export default EscaladorController;

--- a/apps/backend/src/interfaces/http/routes/escaladoresRoutes.js
+++ b/apps/backend/src/interfaces/http/routes/escaladoresRoutes.js
@@ -234,6 +234,70 @@ router.get('/perfil', verifyToken, (req, res, next) => {
 });
 
 /**
+ * PUT /escaladores/actualizarDescripcion
+ * Actualiza la descripcion del escalador autenticado
+ *
+ * Parámetros esperados (body):
+ * - descripcion (@param {String} , opcional): Nueva descripcion (max 255 caracteres)
+ *
+ * Requiere: Token JWT válido en header Authorization
+ *
+ * Respuesta esperada: @return {Object} Perfil del escalador actualizado
+ */
+const actualizarDescripcionValidators = [
+  body('descripcion')
+    .optional({ values: 'falsy' })
+    .isString()
+    .trim()
+    .isLength({ max: 255 })
+    .withMessage('descripcion debe tener maximo 255 caracteres'),
+];
+
+router.put(
+  '/actualizarDescripcion',
+  verifyToken,
+  actualizarDescripcionValidators,
+  validate,
+  (req, res, next) => {
+    escaladorController.actualizarDescripcion(req, res, next);
+  }
+);
+
+/**
+ * PUT /escaladores/cambiarApodo
+ * Actualiza el apodo del escalador autenticado
+ *
+ * Parámetros esperados (body):
+ * - apodo (@param {String} , requerido): Nuevo apodo
+ *
+ * Requiere: Token JWT válido en header Authorization
+ *
+ * Respuesta esperada: @return {Object} Perfil del escalador actualizado y token
+ */
+const cambiarApodoValidators = [
+  body('apodo')
+    .trim()
+    .notEmpty()
+    .withMessage('apodo es requerido')
+    .isLength({ min: 1, max: 20 })
+    .withMessage('apodo debe tener entre 1 y 20 caracteres')
+    .matches(/^[a-zA-Z0-9_-]+$/)
+    .withMessage(
+      'apodo solo puede contener letras, numeros, guiones y guiones bajos'
+    ),
+];
+
+router.put(
+  '/cambiarApodo',
+  verifyToken,
+  cambiarApodoValidators,
+  validate,
+  (req, res, next) => {
+    escaladorController.cambiarApodo(req, res, next);
+  }
+);
+
+/**
  * POST /escaladores/fotos-perfil
  * Crea una nueva imagen de perfil disponible para escaladores
  *

--- a/apps/backend/src/interfaces/http/routes/escaladoresRoutes.js
+++ b/apps/backend/src/interfaces/http/routes/escaladoresRoutes.js
@@ -94,6 +94,60 @@ router.post(
 );
 
 /**
+ * GET /escaladores/validarApodo/:apodo
+ * Verifica si el apodo ya esta registrado en el sistema
+ *
+ * Respuesta esperada: @return {Object} { disponible: boolean }
+ */
+const validarApodoValidators = [
+  param('apodo')
+    .trim()
+    .notEmpty()
+    .withMessage('apodo es requerido')
+    .isLength({ min: 1, max: 20 })
+    .withMessage('apodo debe tener entre 1 y 20 caracteres')
+    .matches(/^[a-zA-Z0-9_-]+$/)
+    .withMessage(
+      'apodo solo puede contener letras, numeros, guiones y guiones bajos'
+    )
+    .toLowerCase(),
+];
+
+router.get(
+  '/validarApodo/:apodo',
+  validarApodoValidators,
+  validate,
+  (req, res, next) => {
+    escaladorController.validarApodo(req, res, next);
+  }
+);
+
+/**
+ * GET /escaladores/validarCorreo/:correo
+ * Verifica si el correo ya esta registrado en el sistema
+ *
+ * Respuesta esperada: @return {Object} { disponible: boolean }
+ */
+const validarCorreoValidators = [
+  param('correo')
+    .trim()
+    .isEmail()
+    .normalizeEmail()
+    .withMessage('correo debe ser un email valido')
+    .notEmpty()
+    .withMessage('correo es requerido'),
+];
+
+router.get(
+  '/validarCorreo/:correo',
+  validarCorreoValidators,
+  validate,
+  (req, res, next) => {
+    escaladorController.validarCorreo(req, res, next);
+  }
+);
+
+/**
  * POST /escaladores/suscribirse
  * Suscribe el escalador autenticado a un rocodromo
  *

--- a/apps/frontend/src/css/global.css
+++ b/apps/frontend/src/css/global.css
@@ -29,6 +29,50 @@ body {
   display: inline-flex;
 }
 
+.app-toast-container {
+  position: fixed;
+  left: 50%;
+  top: 2.75rem;
+  transform: translateX(-50%);
+  z-index: 2100;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  pointer-events: none;
+}
+
+.app-toast {
+  min-width: 220px;
+  max-width: 320px;
+  background: #1f1f1f;
+  border: 2px solid #151515;
+  color: #fff;
+  padding: 0.65rem 0.9rem;
+  border-radius: 12px;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.25);
+  font-size: 0.85rem;
+  line-height: 1.3;
+  opacity: 0;
+  transform: translateY(6px);
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  pointer-events: auto;
+}
+
+.app-toast.is-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.app-toast-danger {
+  background: #dc3545;
+  border-color: #b02a37;
+}
+
+.app-toast-success {
+  background: #198754;
+  border-color: #146c43;
+}
+
 /* Contenedor principal de la app (vertical) */
 #app-container.app-vertical-layout {
   min-height: 100dvh;
@@ -322,23 +366,36 @@ body {
   z-index: 1080;
 }
 
+.perfil-photo-edit-btn,
+.perfil-descripcion-edit-btn,
+.perfil-clear-btn {
+  background-color: #000;
+  border: 2px solid #fff;
+  color: #fff;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+}
+
+.perfil-photo-edit-btn:hover,
+.perfil-photo-edit-btn:focus,
+.perfil-photo-edit-btn:active,
+.perfil-descripcion-edit-btn:hover,
+.perfil-descripcion-edit-btn:focus,
+.perfil-descripcion-edit-btn:active,
+.perfil-clear-btn:hover,
+.perfil-clear-btn:focus,
+.perfil-clear-btn:active {
+  background-color: #000 !important;
+  border-color: #000 !important;
+  color: #fff;
+}
+
 .perfil-photo-edit-btn {
   position: absolute;
   bottom: -4px;
   right: -4px;
   width: 34px;
   height: 34px;
-  background-color: #000;
   border-color: #000;
-  border: 2px solid #fff;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
-}
-
-.perfil-photo-edit-btn:hover,
-.perfil-photo-edit-btn:focus,
-.perfil-photo-edit-btn:active {
-  background-color: #000 !important;
-  border-color: #000 !important;
 }
 
 .perfil-photo-modal-content {
@@ -396,6 +453,101 @@ body {
   justify-content: center;
   align-items: center;
   cursor: pointer;
+}
+
+.perfil-descripcion-divider-wrap {
+  position: relative;
+  margin-top: 0.5rem;
+  width: 100%;
+  max-width: 100%;
+  align-self: center;
+  --divider-extend: 30px;
+  padding: 0 var(--divider-extend);
+  box-sizing: content-box;
+}
+
+.perfil-descripcion-divider {
+  height: 1px;
+  background-color: #dee2e6;
+  width: 100%;
+  display: block;
+}
+
+.perfil-descripcion-edit-btn {
+  position: absolute;
+  top: 50%;
+  right: 0;
+  transform: translateY(-50%);
+  width: 30px;
+  height: 30px;
+  border-radius: 999px;
+}
+
+.perfil-descripcion-wrap,
+.perfil-descripcion-view,
+.perfil-descripcion-edit {
+  width: 100%;
+}
+
+.perfil-apodo-wrap {
+  margin-bottom: 2rem;
+}
+
+.perfil-apodo-view,
+.perfil-descripcion-view {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  width: max-content;
+  max-width: min(100%, 320px);
+  padding: 0 16px;
+  box-sizing: border-box;
+}
+
+.perfil-apodo-view h5,
+.perfil-descripcion-view p {
+  display: inline-block;
+  max-width: 100%;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.perfil-descripcion-actions {
+  display: flex;
+  width: 30px;
+  min-width: 30px;
+  height: 30px;
+  padding: 0;
+  border-radius: 50% !important;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.perfil-input-wrap {
+  position: relative;
+}
+
+.perfil-input-wrap .form-control {
+  padding-right: 52px;
+  padding-left: 14px;
+  padding-top: 8px;
+  padding-bottom: 8px;
+}
+
+.perfil-input-wrap .perfil-clear-btn {
+  position: absolute;
+  right: 8px;
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+.perfil-input-wrap.is-textarea .perfil-clear-btn {
+  top: auto;
+  bottom: 8px;
+  transform: none;
 }
 
 .perfil-photo-radio {

--- a/apps/frontend/src/js/components/editDivider.js
+++ b/apps/frontend/src/js/components/editDivider.js
@@ -1,0 +1,21 @@
+export function renderEditDivider({
+  buttonId,
+  label,
+  title,
+  iconSize = 18,
+} = {}) {
+  return `
+    <div class="perfil-descripcion-divider-wrap">
+      <div class="perfil-descripcion-divider"></div>
+      <button
+        type="button"
+        id="${buttonId}"
+        class="btn btn-sm d-inline-flex align-items-center justify-content-center perfil-descripcion-edit-btn"
+        aria-label="${label}"
+        title="${title}"
+      >
+        <span class="material-icons" style="font-size: ${iconSize}px;">edit</span>
+      </button>
+    </div>
+  `;
+}

--- a/apps/frontend/src/js/components/editableField.js
+++ b/apps/frontend/src/js/components/editableField.js
@@ -1,0 +1,189 @@
+import { renderEditDivider } from './editDivider.js';
+
+function buildAttributes(attributes = {}) {
+  return Object.entries(attributes)
+    .filter(([, value]) => value !== null && value !== undefined && value !== false)
+    .map(([key, value]) => {
+      if (value === true) {
+        return `${key}`;
+      }
+      return `${key}="${value}"`;
+    })
+    .join(' ');
+}
+
+export function renderEditableField({
+  prefix,
+  wrapperClass,
+  viewContent,
+  inputValue,
+  inputTag = 'input',
+  inputClasses = 'form-control form-control-sm',
+  inputAttributes = {},
+  placeholder,
+  ariaLabel,
+  maxLength,
+  rows,
+}) {
+  const dataPrefix = `data-perfil-${prefix}`;
+  const isTextarea = inputTag === 'textarea';
+  const inputAttrs = buildAttributes({
+    id: `perfil-${prefix}-input`,
+    class: inputClasses,
+    placeholder,
+    'aria-label': ariaLabel,
+    maxlength: maxLength,
+    rows: isTextarea ? rows : null,
+    ...inputAttributes,
+  });
+
+  const inputMarkup = isTextarea
+    ? `<textarea ${inputAttrs}>${inputValue}</textarea>`
+    : `<input type="text" ${inputAttrs} value="${inputValue}" />`;
+
+  const dividerMarkup = renderEditDivider({
+    buttonId: `perfil-${prefix}-edit-btn`,
+    label: `Editar ${prefix}`,
+    title: `Editar ${prefix}`,
+  });
+
+  return `
+    <div class="${wrapperClass}" ${dataPrefix}-wrap>
+      <div class="perfil-${prefix}-view" ${dataPrefix}-view>
+        ${viewContent}
+        ${dividerMarkup}
+      </div>
+      <div class="perfil-${prefix}-edit d-none" ${dataPrefix}-edit>
+        <div class="perfil-input-wrap${isTextarea ? ' is-textarea' : ''}">
+          ${inputMarkup}
+          <button
+            type="button"
+            class="btn perfil-clear-btn"
+            id="perfil-${prefix}-clear-btn"
+            aria-label="Vaciar ${prefix}"
+            title="Vaciar ${prefix}"
+          >
+            <span class="material-icons" style="font-size: 18px;">close</span>
+          </button>
+        </div>
+        <div class="perfil-input-counter text-muted small text-end mt-1" ${dataPrefix}-counter></div>
+        <div class="perfil-descripcion-actions mt-2">
+          <button type="button" class="btn btn-sm btn-outline-secondary" id="perfil-${prefix}-cancel-btn">
+            Cancelar
+          </button>
+          <button type="button" class="btn btn-sm btn-primary" id="perfil-${prefix}-submit-btn">
+            Guardar
+          </button>
+        </div>
+      </div>
+    </div>
+  `;
+}
+
+export function initEditableField(container, config) {
+  const {
+    prefix,
+    initialValue,
+    maxLength,
+    onSave,
+    onOpen,
+    disableWhenEmpty = false,
+  } = config;
+
+  const wrap = container.querySelector(`[data-perfil-${prefix}-wrap]`);
+  const view = container.querySelector(`[data-perfil-${prefix}-view]`);
+  const edit = container.querySelector(`[data-perfil-${prefix}-edit]`);
+  const input = container.querySelector(`#perfil-${prefix}-input`);
+  const editBtn = container.querySelector(`#perfil-${prefix}-edit-btn`);
+  const cancelBtn = container.querySelector(`#perfil-${prefix}-cancel-btn`);
+  const clearBtn = container.querySelector(`#perfil-${prefix}-clear-btn`);
+  const counter = container.querySelector(`[data-perfil-${prefix}-counter]`);
+  const submitBtn = container.querySelector(`#perfil-${prefix}-submit-btn`);
+
+  if (!wrap || !view || !edit || !input || !editBtn || !cancelBtn || !clearBtn) {
+    return null;
+  }
+
+  const initialNormalized = typeof initialValue === 'string'
+    ? initialValue.trim()
+    : (input.value || '').trim();
+  const counterMax = Number.isInteger(maxLength) ? maxLength : input.maxLength;
+
+  const updateCounter = () => {
+    if (!counter || !counterMax) {
+      return;
+    }
+    const length = input.value.length;
+    counter.textContent = `${length}/${counterMax}`;
+  };
+
+  const updateSaveState = () => {
+    if (!submitBtn) {
+      return;
+    }
+    const trimmed = input.value.trim();
+    const isEmptyDisabled = disableWhenEmpty && trimmed === '';
+    submitBtn.disabled = isEmptyDisabled || trimmed === initialNormalized;
+  };
+
+  const close = () => {
+    edit.classList.add('d-none');
+    view.classList.remove('d-none');
+    input.value = initialNormalized;
+    updateCounter();
+    updateSaveState();
+  };
+
+  const open = () => {
+    if (typeof onOpen === 'function') {
+      onOpen();
+    }
+    view.classList.add('d-none');
+    edit.classList.remove('d-none');
+    input.focus();
+    input.select();
+    updateCounter();
+    updateSaveState();
+  };
+
+  editBtn.addEventListener('click', (event) => {
+    event.preventDefault();
+    open();
+  });
+
+  cancelBtn.addEventListener('click', (event) => {
+    event.preventDefault();
+    close();
+  });
+
+  clearBtn.addEventListener('click', (event) => {
+    event.preventDefault();
+    input.value = '';
+    updateCounter();
+    updateSaveState();
+    input.focus();
+  });
+
+  input.addEventListener('input', () => {
+    updateCounter();
+    updateSaveState();
+  });
+
+  if (submitBtn && typeof onSave === 'function') {
+    submitBtn.addEventListener('click', async (event) => {
+      event.preventDefault();
+      const value = input.value.trim();
+      submitBtn.disabled = true;
+      try {
+        await onSave(value);
+      } finally {
+        submitBtn.disabled = false;
+      }
+    });
+  }
+
+  updateCounter();
+  updateSaveState();
+
+  return { open, close, updateSaveState };
+}

--- a/apps/frontend/src/js/components/toast.js
+++ b/apps/frontend/src/js/components/toast.js
@@ -1,0 +1,33 @@
+export function showToast(message, options = {}) {
+    const { duration = 3500, variant = 'danger' } = options;
+    const containerId = 'app-toast-container';
+    let container = document.getElementById(containerId);
+
+    if (!container) {
+        container = document.createElement('div');
+        container.id = containerId;
+        container.className = 'app-toast-container';
+        document.body.appendChild(container);
+    }
+
+    const toast = document.createElement('div');
+    toast.className = `app-toast app-toast-${variant}`;
+    toast.setAttribute('role', 'status');
+    toast.textContent = message;
+    container.appendChild(toast);
+
+    requestAnimationFrame(() => {
+        toast.classList.add('is-visible');
+    });
+
+    const timeoutId = window.setTimeout(() => {
+        toast.classList.remove('is-visible');
+        window.setTimeout(() => toast.remove(), 300);
+    }, duration);
+
+    toast.addEventListener('click', () => {
+        window.clearTimeout(timeoutId);
+        toast.classList.remove('is-visible');
+        window.setTimeout(() => toast.remove(), 300);
+    });
+}

--- a/apps/frontend/src/js/modules/escalador/escaladorController.js
+++ b/apps/frontend/src/js/modules/escalador/escaladorController.js
@@ -1,6 +1,7 @@
 import { renderPerfil } from './escaladorView.js';
-import { fetchClient, fetchImageObjectUrl, removeToken } from '../../core/client.js';
+import { fetchClient, fetchImageObjectUrl, removeToken, saveToken } from '../../core/client.js';
 import { showLoading, showError } from '../../core/ui.js';
+import { showToast } from '../../components/toast.js';
 import { showProfilePhotoModal } from '../../components/profilePhotoModal.js';
 
 const PERFIL_PLACEHOLDER = '/assets/johnDoe.png';
@@ -77,6 +78,37 @@ async function abrirCambioFotoPerfil(container, escalador) {
     }
 }
 
+async function validarApodo(apodo) {
+    try {
+        const response = await fetchClient(`/escaladores/validarApodo/${encodeURIComponent(apodo)}`);
+        const data = await response.json();
+        if (data?.disponible === false) {
+            return { ok: false, message: 'El apodo no esta disponible.' };
+        }
+        return { ok: true };
+    } catch (err) {
+        const errorMsg = await extractValidatorMessage(err);
+        return { ok: false, message: errorMsg || err.message || 'No se pudo validar el apodo.' };
+    }
+}
+
+async function extractValidatorMessage(err) {
+    if (!err?.response) {
+        return null;
+    }
+
+    try {
+        const payload = await err.response.json();
+        const errorMsg = payload?.errors?.[0]?.msg;
+        if (errorMsg) {
+            return errorMsg;
+        }
+        return payload?.message || payload?.error || null;
+    } catch {
+        return null;
+    }
+}
+
 // Controlador para la vista de perfil del usuario
 export async function perfilCmd(container) {
     showLoading();
@@ -110,6 +142,53 @@ export async function perfilCmd(container) {
             },
             onOpenChangePhoto: async () => {
                 await abrirCambioFotoPerfil(container, escalador);
+            },
+            onUpdateDescripcion: async (descripcion) => {
+                try {
+                    const response = await fetchClient('/escaladores/actualizarDescripcion', {
+                        method: 'PUT',
+                        headers: {
+                            'Content-Type': 'application/json'
+                        },
+                        body: JSON.stringify({ descripcion })
+                    });
+
+                    const updated = await response.json();
+                    escalador.descripcion = updated?.descripcion ?? descripcion;
+                    renderPerfil(container, escalador, callbacks);
+                    showToast('Descripcion actualizada correctamente.', { variant: 'success' });
+                } catch (err) {
+                    const errorMsg = await extractValidatorMessage(err);
+                    showToast(`No se ha podido completar el cambio: ${errorMsg || err.message}`);
+                }
+            },
+            onUpdateApodo: async (apodo) => {
+                try {
+                    const validation = await validarApodo(apodo);
+                    if (!validation.ok) {
+                        showToast(`No se ha podido completar el cambio: ${validation.message}`);
+                        return;
+                    }
+
+                    const response = await fetchClient('/escaladores/cambiarApodo', {
+                        method: 'PUT',
+                        headers: {
+                            'Content-Type': 'application/json'
+                        },
+                        body: JSON.stringify({ apodo })
+                    });
+
+                    const updated = await response.json();
+                    if (updated?.token) {
+                        saveToken(updated.token);
+                    }
+                    escalador.apodo = updated?.apodo ?? apodo;
+                    renderPerfil(container, escalador, callbacks);
+                    showToast('Apodo actualizado correctamente.', { variant: 'success' });
+                } catch (err) {
+                    const errorMsg = await extractValidatorMessage(err);
+                    showToast(`No se ha podido completar el cambio: ${errorMsg || err.message}`);
+                }
             }
         };
 

--- a/apps/frontend/src/js/modules/escalador/escaladorView.js
+++ b/apps/frontend/src/js/modules/escalador/escaladorView.js
@@ -1,11 +1,13 @@
 import { renderNavbar } from '../../components/navbar.js';
 import { showConfirmModal } from '../../components/modal.js';
 import { escapeHtml } from '../../components/formHelpers.js';
+import { renderEditableField, initEditableField } from '../../components/editableField.js';
 
 // Vista del perfil del escalador
 export function renderPerfil(container, escalador, callbacks) {
   const { apodo, descripcion, fotoSrc } = escalador;
   const avatar = fotoSrc || '/assets/johnDoe.png';
+  const apodoLimpio = typeof apodo === 'string' ? apodo.trim() : '';
   const descripcionLimpia =
     typeof descripcion === 'string' ? descripcion.trim() : '';
   const descripcionVisible =
@@ -79,8 +81,35 @@ export function renderPerfil(container, escalador, callbacks) {
               <span class="material-icons" style="font-size: 18px;">photo_camera</span>
             </button>
           </div>
-          <h5 class="fw-bold mb-1">${apodo}</h5>
-          ${descripcionVisible ? `<p class="text-muted mb-0">${descripcionVisible}</p>` : ''}
+          ${renderEditableField({
+            prefix: 'apodo',
+            wrapperClass: 'perfil-apodo-wrap',
+            viewContent: `<h5 class="fw-bold mb-1">${apodo}</h5>`,
+            inputValue: escapeHtml(apodoLimpio),
+            inputTag: 'input',
+            placeholder: 'Edita tu apodo',
+            ariaLabel: 'Apodo',
+            maxLength: 20,
+            inputAttributes: {
+              autocomplete: 'off',
+              autocapitalize: 'off',
+              autocorrect: 'off',
+              spellcheck: 'false',
+            },
+          })}
+          ${renderEditableField({
+            prefix: 'descripcion',
+            wrapperClass: 'perfil-descripcion-wrap mt-2',
+            viewContent: `<div class="text-center">${descripcionVisible
+              ? `<p class="text-muted mb-0">${descripcionVisible}</p>`
+              : '<p class="text-muted mb-0 small fst-italic">Sin descripcion...</p>'}</div>`,
+            inputValue: escapeHtml(descripcionLimpia),
+            inputTag: 'textarea',
+            placeholder: 'Anade una descripcion',
+            ariaLabel: 'Descripcion',
+            maxLength: 255,
+            rows: 7,
+          })}
         </div>
       </div>
 
@@ -116,5 +145,26 @@ export function renderPerfil(container, escalador, callbacks) {
   const openChangePhotoBtn = container.querySelector('#open-change-photo-btn');
   openChangePhotoBtn.addEventListener('click', () => {
     callbacks.onOpenChangePhoto();
+  });
+
+  let apodoField = null;
+  let descripcionField = null;
+
+  apodoField = initEditableField(container, {
+    prefix: 'apodo',
+    initialValue: apodoLimpio,
+    maxLength: 20,
+    onSave: callbacks?.onUpdateApodo,
+    onOpen: () => descripcionField?.close(),
+    disableWhenEmpty: true,
+  });
+
+  descripcionField = initEditableField(container, {
+    prefix: 'descripcion',
+    initialValue: descripcionLimpia,
+    maxLength: 255,
+    onSave: callbacks?.onUpdateDescripcion,
+    onOpen: () => apodoField?.close(),
+    disableWhenEmpty: false,
   });
 }


### PR DESCRIPTION
Frontend:
1. Nuevo editor de apodo y descripción en el perfil, con contador y botones claros.
2. Mensajes tipo toast para errores y confirmaciones.
3. Mejoras en la lógica de guardado (validaciones y actualización de datos)

Backend:
1. Implementados endpoints de validacion para apodo y correo, con verificacion de apodo insensible a mayusculas.
2. Implementados endpoints PUT para actualizar descripcion y cambiar apodo con JWT, devolviendo el perfil actualizado y un nuevo token.
3. Nuevos tests unitarios y E2E para los endpoints implementados.