### PR TITLE
Feat estadisticas basicas escalador

### DIFF
--- a/apps/backend/__tests__/e2e/escalador.e2e.test.js
+++ b/apps/backend/__tests__/e2e/escalador.e2e.test.js
@@ -6,6 +6,15 @@ import tokenService from '../../src/infrastructure/security/tokenService.js';
 const db = await dbPromise;
 
 describe('E2E: Escalador', () => {
+  const FIXTURE_CORREOS = [
+    'e2e@test.com',
+    'suscripcion@test.com',
+    'validacion@test.com',
+    'descripcion@test.com',
+    'cambio-apodo@test.com',
+    'sin-suscripcion@test.com',
+  ];
+  const FIXTURE_ROCODROMO_NOMBRE = 'Boulder Test E2E';
   const escaladorTest = {
     correo: 'e2e@test.com',
     contrasena: 'Password123',
@@ -15,13 +24,40 @@ describe('E2E: Escalador', () => {
   let escaladorSuscripcion;
   let rocodromoTest;
   let tokenSuscripcion;
+  // eslint-disable-next-line no-unused-vars
   let escaladorValidacion;
   let escaladorDescripcion;
   let escaladorCambioApodo;
   let tokenDescripcion;
   let tokenCambioApodo;
 
+  async function limpiarFixturesEscaladorE2E() {
+    const rocodromos = await db.Rocodromo.findAll({
+      where: { nombre: FIXTURE_ROCODROMO_NOMBRE },
+      attributes: ['id'],
+    });
+    const idsRocodromos = rocodromos.map((r) => r.id);
+
+    const escaladores = await db.Escalador.findAll({
+      where: { correo: FIXTURE_CORREOS },
+      attributes: ['id'],
+    });
+    const idsEscaladores = escaladores.map((e) => e.id);
+
+    if (idsEscaladores.length > 0) {
+      await db.Suscripcion.destroy({ where: { idEscalador: idsEscaladores } });
+    }
+    if (idsRocodromos.length > 0) {
+      await db.Suscripcion.destroy({ where: { idRocodromo: idsRocodromos } });
+    }
+
+    await db.Escalador.destroy({ where: { correo: FIXTURE_CORREOS } });
+    await db.Rocodromo.destroy({ where: { nombre: FIXTURE_ROCODROMO_NOMBRE } });
+  }
+
   beforeAll(async () => {
+    await limpiarFixturesEscaladorE2E();
+
     // Crear escalador de prueba para suscripción
     escaladorSuscripcion = await db.Escalador.create({
       correo: 'suscripcion@test.com',
@@ -41,6 +77,7 @@ describe('E2E: Escalador', () => {
       apodo: escaladorSuscripcion.apodo 
     });
 
+     
     escaladorValidacion = await db.Escalador.create({
       correo: 'validacion@test.com',
       contrasena: 'hashedPassword123',
@@ -72,26 +109,7 @@ describe('E2E: Escalador', () => {
   });
 
   afterAll(async () => {
-    // Limpiar registros
-    await db.Escalador.destroy({ where: { correo: escaladorTest.correo } });
-    
-    // Limpiar asociaciones y registros de suscripción
-    if (escaladorSuscripcion && rocodromoTest) {
-      try {
-        await escaladorSuscripcion.removeRocodromo(rocodromoTest.id);
-      } catch (error) {
-        // Ignorar si ya fue eliminado
-        error;
-      }
-    }
-    if (escaladorSuscripcion) await escaladorSuscripcion.destroy();
-    if (escaladorValidacion) await escaladorValidacion.destroy();
-    if (escaladorDescripcion) await escaladorDescripcion.destroy();
-    if (escaladorCambioApodo) {
-      await db.Escalador.destroy({ where: { correo: escaladorCambioApodo.correo } });
-    }
-    if (rocodromoTest) await rocodromoTest.destroy();
-    
+    await limpiarFixturesEscaladorE2E();
     await db.sequelize.close();
   });
 

--- a/apps/backend/__tests__/unit/application/escaladores/obtenerActividadMensualEscalador.test.js
+++ b/apps/backend/__tests__/unit/application/escaladores/obtenerActividadMensualEscalador.test.js
@@ -1,0 +1,74 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import ObtenerActividadMensualEscalador from '../../../../src/application/escaladores/obtenerActividadMensualEscalador.js';
+import {
+  BadRequestError,
+  InternalServerError,
+  NotFoundError,
+} from '../../../../src/domain/sharedObjects/AppError.js';
+
+describe('ObtenerActividadMensualEscalador', () => {
+  it('deberia obtener actividad mensual para un escalador existente', async () => {
+    const mockEscaladorRepository = {
+      encontrarPorApodo: jest.fn().mockResolvedValue({ id: 9 }),
+    };
+    const mockPistaRepository = {
+      obtenerActividadMensualEscalador: jest.fn().mockResolvedValue({
+        year: 2026,
+        month: 4,
+        actividadMensual: [{ dia: 10, rutas: 2 }],
+      }),
+    };
+
+    const useCase = new ObtenerActividadMensualEscalador(
+      mockEscaladorRepository,
+      mockPistaRepository
+    );
+
+    const resultado = await useCase.execute({ apodo: 'Tester', year: 2026, month: 4 });
+
+    expect(mockEscaladorRepository.encontrarPorApodo).toHaveBeenCalledWith('Tester');
+    expect(mockPistaRepository.obtenerActividadMensualEscalador).toHaveBeenCalledWith(
+      9,
+      2026,
+      4
+    );
+    expect(resultado).toEqual({
+      year: 2026,
+      month: 4,
+      actividadMensual: [{ dia: 10, rutas: 2 }],
+    });
+  });
+
+  it('deberia lanzar NotFoundError si no existe el escalador', async () => {
+    const useCase = new ObtenerActividadMensualEscalador(
+      { encontrarPorApodo: jest.fn().mockResolvedValue(null) },
+      { obtenerActividadMensualEscalador: jest.fn() }
+    );
+
+    await expect(useCase.execute({ apodo: 'NoExiste', year: 2026, month: 4 })).rejects.toBeInstanceOf(
+      NotFoundError
+    );
+  });
+
+  it('deberia lanzar BadRequestError con month fuera de rango', async () => {
+    const useCase = new ObtenerActividadMensualEscalador(
+      { encontrarPorApodo: jest.fn().mockResolvedValue({ id: 1 }) },
+      { obtenerActividadMensualEscalador: jest.fn() }
+    );
+
+    await expect(useCase.execute({ apodo: 'Tester', year: 2026, month: 13 })).rejects.toBeInstanceOf(
+      BadRequestError
+    );
+  });
+
+  it('deberia lanzar InternalServerError ante fallo inesperado', async () => {
+    const useCase = new ObtenerActividadMensualEscalador(
+      { encontrarPorApodo: jest.fn().mockRejectedValue(new Error('db fail')) },
+      { obtenerActividadMensualEscalador: jest.fn() }
+    );
+
+    await expect(useCase.execute({ apodo: 'Tester', year: 2026, month: 4 })).rejects.toBeInstanceOf(
+      InternalServerError
+    );
+  });
+});

--- a/apps/backend/__tests__/unit/application/escaladores/obtenerResumenEstadisticasEscalador.test.js
+++ b/apps/backend/__tests__/unit/application/escaladores/obtenerResumenEstadisticasEscalador.test.js
@@ -1,0 +1,73 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import ObtenerResumenEstadisticasEscalador from '../../../../src/application/escaladores/obtenerResumenEstadisticasEscalador.js';
+import { InternalServerError, NotFoundError } from '../../../../src/domain/sharedObjects/AppError.js';
+
+describe('ObtenerResumenEstadisticasEscalador', () => {
+  it('deberia obtener el resumen de estadisticas de un escalador existente', async () => {
+    const mockEscaladorRepository = {
+      encontrarPorApodo: jest.fn().mockResolvedValue({ id: 4, apodo: 'Ivan' }),
+    };
+    const mockPistaRepository = {
+      obtenerResumenEstadisticasEscalador: jest.fn().mockResolvedValue({
+        totalRutas: 12,
+        totalFlash: 5,
+        totalCompletado: 7,
+        totalProyecto: 2,
+        porcentajeFlash: 41.67,
+      }),
+    };
+
+    const useCase = new ObtenerResumenEstadisticasEscalador(
+      mockEscaladorRepository,
+      mockPistaRepository
+    );
+
+    const resultado = await useCase.execute({ apodo: 'Ivan' });
+
+    expect(mockEscaladorRepository.encontrarPorApodo).toHaveBeenCalledWith('Ivan');
+    expect(mockPistaRepository.obtenerResumenEstadisticasEscalador).toHaveBeenCalledWith(4);
+    expect(resultado).toEqual({
+      totalRutas: 12,
+      totalFlash: 5,
+      totalCompletado: 7,
+      totalProyecto: 2,
+      porcentajeFlash: 41.67,
+    });
+  });
+
+  it('deberia lanzar NotFoundError si el escalador no existe', async () => {
+    const mockEscaladorRepository = {
+      encontrarPorApodo: jest.fn().mockResolvedValue(null),
+    };
+    const mockPistaRepository = {
+      obtenerResumenEstadisticasEscalador: jest.fn(),
+    };
+
+    const useCase = new ObtenerResumenEstadisticasEscalador(
+      mockEscaladorRepository,
+      mockPistaRepository
+    );
+
+    await expect(useCase.execute({ apodo: 'NoExiste' })).rejects.toBeInstanceOf(
+      NotFoundError
+    );
+  });
+
+  it('deberia lanzar InternalServerError cuando falla una dependencia', async () => {
+    const mockEscaladorRepository = {
+      encontrarPorApodo: jest.fn().mockRejectedValue(new Error('db fail')),
+    };
+    const mockPistaRepository = {
+      obtenerResumenEstadisticasEscalador: jest.fn(),
+    };
+
+    const useCase = new ObtenerResumenEstadisticasEscalador(
+      mockEscaladorRepository,
+      mockPistaRepository
+    );
+
+    await expect(useCase.execute({ apodo: 'Ivan' })).rejects.toBeInstanceOf(
+      InternalServerError
+    );
+  });
+});

--- a/apps/backend/__tests__/unit/application/escaladores/obtenerTiposEstadisticasEscalador.test.js
+++ b/apps/backend/__tests__/unit/application/escaladores/obtenerTiposEstadisticasEscalador.test.js
@@ -1,0 +1,75 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import ObtenerTiposEstadisticasEscalador from '../../../../src/application/escaladores/obtenerTiposEstadisticasEscalador.js';
+import { InternalServerError, NotFoundError } from '../../../../src/domain/sharedObjects/AppError.js';
+
+describe('ObtenerTiposEstadisticasEscalador', () => {
+  it('deberia obtener distribucion por tipo para un escalador existente', async () => {
+    const mockEscaladorRepository = {
+      encontrarPorApodo: jest.fn().mockResolvedValue({ id: 3, apodo: 'Climber' }),
+    };
+    const mockPistaRepository = {
+      obtenerTiposEstadisticasEscalador: jest.fn().mockResolvedValue({
+        totalBloques: 8,
+        totalVias: 4,
+        porcentajeBloques: 66.67,
+        porcentajeVias: 33.33,
+        favoritaTexto: 'Bloque',
+      }),
+    };
+
+    const useCase = new ObtenerTiposEstadisticasEscalador(
+      mockEscaladorRepository,
+      mockPistaRepository
+    );
+
+    const resultado = await useCase.execute({ apodo: 'Climber' });
+
+    expect(mockEscaladorRepository.encontrarPorApodo).toHaveBeenCalledWith(
+      'Climber'
+    );
+    expect(mockPistaRepository.obtenerTiposEstadisticasEscalador).toHaveBeenCalledWith(3);
+    expect(resultado).toEqual({
+      totalBloques: 8,
+      totalVias: 4,
+      porcentajeBloques: 66.67,
+      porcentajeVias: 33.33,
+      favoritaTexto: 'Bloque',
+    });
+  });
+
+  it('deberia lanzar NotFoundError si el escalador no existe', async () => {
+    const mockEscaladorRepository = {
+      encontrarPorApodo: jest.fn().mockResolvedValue(null),
+    };
+    const mockPistaRepository = {
+      obtenerTiposEstadisticasEscalador: jest.fn(),
+    };
+
+    const useCase = new ObtenerTiposEstadisticasEscalador(
+      mockEscaladorRepository,
+      mockPistaRepository
+    );
+
+    await expect(useCase.execute({ apodo: 'NoExiste' })).rejects.toBeInstanceOf(
+      NotFoundError
+    );
+  });
+
+  it('deberia lanzar InternalServerError cuando falla una dependencia', async () => {
+    const mockEscaladorRepository = {
+      encontrarPorApodo: jest.fn().mockRejectedValue(new Error('db fail')),
+    };
+    const mockPistaRepository = {
+      obtenerTiposEstadisticasEscalador: jest.fn(),
+    };
+
+    const useCase = new ObtenerTiposEstadisticasEscalador(
+      mockEscaladorRepository,
+      mockPistaRepository
+    );
+
+    await expect(useCase.execute({ apodo: 'Climber' })).rejects.toBeInstanceOf(
+      InternalServerError
+    );
+  });
+});

--- a/apps/backend/__tests__/unit/controllers/escaladorController.test.js
+++ b/apps/backend/__tests__/unit/controllers/escaladorController.test.js
@@ -421,5 +421,37 @@ describe('Unit: EscaladorController', () => {
       expect(res.status).toHaveBeenCalledWith(200);
       expect(res.body).toEqual({ totalBloques: 4, totalVias: 2 });
     });
+
+    it('obtenerActividadMensual usa query params y responde 200', async () => {
+      const useCases = {
+        obtenerActividadMensual: {
+          execute: jest.fn().mockResolvedValue({
+            year: 2026,
+            month: 4,
+            actividadMensual: [{ dia: 1, rutas: 2 }],
+          }),
+        },
+      };
+      const controller = new EscaladorController(useCases);
+      const req = {
+        user: { apodo: 'Tester' },
+        query: { year: '2026', month: '4' },
+      };
+      const res = createResMock();
+
+      await controller.obtenerActividadMensual(req, res, () => {});
+
+      expect(useCases.obtenerActividadMensual.execute).toHaveBeenCalledWith({
+        apodo: 'Tester',
+        year: 2026,
+        month: 4,
+      });
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.body).toEqual({
+        year: 2026,
+        month: 4,
+        actividadMensual: [{ dia: 1, rutas: 2 }],
+      });
+    });
   });
 });

--- a/apps/backend/__tests__/unit/controllers/escaladorController.test.js
+++ b/apps/backend/__tests__/unit/controllers/escaladorController.test.js
@@ -382,4 +382,44 @@ describe('Unit: EscaladorController', () => {
       expect(res.body).toEqual({ fotoUrl: '/uploads/fotos_perfil/foto.png' });
     });
   });
+
+  describe('estadisticas', () => {
+    it('obtenerResumenEstadisticas responde 200 con datos del escalador autenticado', async () => {
+      const useCases = {
+        obtenerResumenEstadisticas: {
+          execute: jest.fn().mockResolvedValue({ totalRutas: 9, totalFlash: 3 }),
+        },
+      };
+      const controller = new EscaladorController(useCases);
+      const req = { user: { apodo: 'Tester' } };
+      const res = createResMock();
+
+      await controller.obtenerResumenEstadisticas(req, res, () => {});
+
+      expect(useCases.obtenerResumenEstadisticas.execute).toHaveBeenCalledWith({
+        apodo: 'Tester',
+      });
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.body).toEqual({ totalRutas: 9, totalFlash: 3 });
+    });
+
+    it('obtenerTiposEstadisticasPublico responde 200 con datos del apodo en params', async () => {
+      const useCases = {
+        obtenerTiposEstadisticas: {
+          execute: jest.fn().mockResolvedValue({ totalBloques: 4, totalVias: 2 }),
+        },
+      };
+      const controller = new EscaladorController(useCases);
+      const req = { params: { apodo: 'PerfilPublico' } };
+      const res = createResMock();
+
+      await controller.obtenerTiposEstadisticasPublico(req, res, () => {});
+
+      expect(useCases.obtenerTiposEstadisticas.execute).toHaveBeenCalledWith({
+        apodo: 'PerfilPublico',
+      });
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.body).toEqual({ totalBloques: 4, totalVias: 2 });
+    });
+  });
 });

--- a/apps/backend/__tests__/unit/repositories/PistaRepositoryPostgres.test.js
+++ b/apps/backend/__tests__/unit/repositories/PistaRepositoryPostgres.test.js
@@ -11,6 +11,14 @@ describe('PistaRepositoryPostgres', () => {
     mockPistaModel = {
       create: jest.fn(),
       findByPk: jest.fn(),
+      findAll: jest.fn(),
+      sequelize: {
+        models: {
+          EscalaPista: {
+            findAll: jest.fn(),
+          },
+        },
+      },
     };
 
     // Instanciamos el repositorio con el modelo mockeado
@@ -249,6 +257,84 @@ describe('PistaRepositoryPostgres', () => {
 
       const resultado = await repository.obtenerEstado(1, 5);
       expect(resultado).toBeNull();
+    });
+  });
+
+  describe('obtenerResumenEstadisticasEscalador', () => {
+    it('deberia retornar resumen agregado por estado', async () => {
+      mockPistaModel.sequelize.models.EscalaPista.findAll.mockResolvedValue([
+        { estado: 'flash', total: '2' },
+        { estado: 'completado', total: '5' },
+        { estado: 'proyecto', total: '3' },
+      ]);
+
+      const resultado = await repository.obtenerResumenEstadisticasEscalador(9);
+
+      expect(
+        mockPistaModel.sequelize.models.EscalaPista.findAll
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { idEscalador: 9 },
+          raw: true,
+        })
+      );
+      expect(resultado.totalRutas).toBe(7);
+      expect(resultado.totalFlash).toBe(2);
+      expect(resultado.totalCompletado).toBe(5);
+      expect(resultado.totalProyecto).toBe(3);
+      expect(resultado.porcentajeFlash).toBeCloseTo(28.57142857, 8);
+    });
+
+    it('deberia retornar valores en cero cuando no hay datos', async () => {
+      mockPistaModel.sequelize.models.EscalaPista.findAll.mockResolvedValue([]);
+
+      const resultado = await repository.obtenerResumenEstadisticasEscalador(3);
+
+      expect(resultado).toEqual({
+        totalRutas: 0,
+        totalFlash: 0,
+        totalCompletado: 0,
+        totalProyecto: 0,
+        porcentajeFlash: 0,
+      });
+    });
+  });
+
+  describe('obtenerTiposEstadisticasEscalador', () => {
+    it('deberia retornar distribucion agregada por tipo', async () => {
+      mockPistaModel.findAll.mockResolvedValue([
+        { tipo: 'boulder', total: '8' },
+        { tipo: 'via', total: '2' },
+      ]);
+
+      const resultado = await repository.obtenerTiposEstadisticasEscalador(5);
+
+      expect(mockPistaModel.findAll).toHaveBeenCalledWith(
+        expect.objectContaining({
+          raw: true,
+        })
+      );
+      expect(resultado).toEqual({
+        totalBloques: 8,
+        totalVias: 2,
+        porcentajeBloques: 80,
+        porcentajeVias: 20,
+        favoritaTexto: 'Bloque',
+      });
+    });
+
+    it('deberia retornar valores en cero cuando no hay rutas escaladas', async () => {
+      mockPistaModel.findAll.mockResolvedValue([]);
+
+      const resultado = await repository.obtenerTiposEstadisticasEscalador(5);
+
+      expect(resultado).toEqual({
+        totalBloques: 0,
+        totalVias: 0,
+        porcentajeBloques: 0,
+        porcentajeVias: 0,
+        favoritaTexto: 'Bloque',
+      });
     });
   });
 });

--- a/apps/backend/__tests__/unit/repositories/PistaRepositoryPostgres.test.js
+++ b/apps/backend/__tests__/unit/repositories/PistaRepositoryPostgres.test.js
@@ -13,6 +13,7 @@ describe('PistaRepositoryPostgres', () => {
       findByPk: jest.fn(),
       findAll: jest.fn(),
       sequelize: {
+        query: jest.fn(),
         models: {
           EscalaPista: {
             findAll: jest.fn(),
@@ -334,6 +335,46 @@ describe('PistaRepositoryPostgres', () => {
         porcentajeBloques: 0,
         porcentajeVias: 0,
         favoritaTexto: 'Bloque',
+      });
+    });
+  });
+
+  describe('obtenerActividadMensualEscalador', () => {
+    it('deberia retornar actividad mensual agregada por dia', async () => {
+      mockPistaModel.sequelize.query.mockResolvedValue([
+        { dia: 3, rutas: 2 },
+        { dia: 7, rutas: 1 },
+      ]);
+
+      const resultado = await repository.obtenerActividadMensualEscalador(5, 2026, 4);
+
+      expect(mockPistaModel.sequelize.query).toHaveBeenCalledWith(
+        expect.stringContaining('FROM "Pistas" p'),
+        expect.objectContaining({
+          replacements: expect.objectContaining({
+            idEscalador: 5,
+          }),
+        })
+      );
+      expect(resultado).toEqual({
+        year: 2026,
+        month: 4,
+        actividadMensual: [
+          { dia: 3, rutas: 2 },
+          { dia: 7, rutas: 1 },
+        ],
+      });
+    });
+
+    it('deberia retornar actividad vacia cuando no hay datos', async () => {
+      mockPistaModel.sequelize.query.mockResolvedValue([]);
+
+      const resultado = await repository.obtenerActividadMensualEscalador(5, 2026, 4);
+
+      expect(resultado).toEqual({
+        year: 2026,
+        month: 4,
+        actividadMensual: [],
       });
     });
   });

--- a/apps/backend/__tests__/unit/repositories/PistaRepositoryPostgres.test.js
+++ b/apps/backend/__tests__/unit/repositories/PistaRepositoryPostgres.test.js
@@ -129,7 +129,10 @@ describe('PistaRepositoryPostgres', () => {
         }],
       });
       expect(mockPistaInstance.addEscaladores).toHaveBeenCalledWith(idEscalador, { 
-        through: { estado: nuevoEstado } 
+        through: {
+          estado: nuevoEstado,
+          fechaCompletado: expect.any(Date),
+        }
       });
     });
 
@@ -168,7 +171,37 @@ describe('PistaRepositoryPostgres', () => {
           required: false,
         }],
       });
-      expect(mockEscalaPistaData.update).toHaveBeenCalledWith({ estado: nuevoEstado });
+      expect(mockEscalaPistaData.update).toHaveBeenCalledWith({
+        estado: nuevoEstado,
+        fechaCompletado: expect.any(Date),
+      });
+    });
+
+    it('debería limpiar fechaCompletado al cambiar a proyecto', async () => {
+      const idPista = 2;
+      const idEscalador = 3;
+      const nuevoEstado = 'proyecto';
+
+      const mockEscalaPistaData = {
+        update: jest.fn().mockResolvedValue(true),
+      };
+
+      const mockPistaInstance = {
+        id: idPista,
+        escaladores: [{
+          id: idEscalador,
+          EscalaPista: mockEscalaPistaData,
+        }],
+      };
+
+      mockPistaModel.findByPk.mockResolvedValue(mockPistaInstance);
+
+      await repository.cambiarEstado(idPista, idEscalador, nuevoEstado);
+
+      expect(mockEscalaPistaData.update).toHaveBeenCalledWith({
+        estado: 'proyecto',
+        fechaCompletado: null,
+      });
     });
 
     it('debería lanzar un error si la pista no existe', async () => {
@@ -342,14 +375,14 @@ describe('PistaRepositoryPostgres', () => {
   describe('obtenerActividadMensualEscalador', () => {
     it('deberia retornar actividad mensual agregada por dia', async () => {
       mockPistaModel.sequelize.query.mockResolvedValue([
-        { dia: 3, rutas: 2 },
-        { dia: 7, rutas: 1 },
+        { fechaCompletado: '2026-04-03', dia: 3, rutas: 2 },
+        { fechaCompletado: '2026-04-07', dia: 7, rutas: 1 },
       ]);
 
       const resultado = await repository.obtenerActividadMensualEscalador(5, 2026, 4);
 
       expect(mockPistaModel.sequelize.query).toHaveBeenCalledWith(
-        expect.stringContaining('FROM "Pistas" p'),
+        expect.stringContaining('FROM "EscalaPista" ep'),
         expect.objectContaining({
           replacements: expect.objectContaining({
             idEscalador: 5,
@@ -360,8 +393,8 @@ describe('PistaRepositoryPostgres', () => {
         year: 2026,
         month: 4,
         actividadMensual: [
-          { dia: 3, rutas: 2 },
-          { dia: 7, rutas: 1 },
+          { fechaCompletado: '2026-04-03', dia: 3, rutas: 2 },
+          { fechaCompletado: '2026-04-07', dia: 7, rutas: 1 },
         ],
       });
     });

--- a/apps/backend/src/application/escaladores/obtenerActividadMensualEscalador.js
+++ b/apps/backend/src/application/escaladores/obtenerActividadMensualEscalador.js
@@ -1,0 +1,53 @@
+import {
+  AppError,
+  BadRequestError,
+  InternalServerError,
+  NotFoundError,
+} from '../../domain/sharedObjects/AppError.js';
+
+class ObtenerActividadMensualEscalador {
+  constructor(escaladorRepository, pistaRepository) {
+    this.escaladorRepository = escaladorRepository;
+    this.pistaRepository = pistaRepository;
+  }
+
+  async execute({ apodo, year, month }) {
+    try {
+      const escalador = await this.escaladorRepository.encontrarPorApodo(apodo);
+
+      if (!escalador) {
+        throw new NotFoundError('Escalador no encontrado', 'ESCALADOR_NOT_FOUND');
+      }
+
+      const now = new Date();
+      const resolvedYear = Number.isInteger(year) ? year : now.getFullYear();
+      const resolvedMonth = Number.isInteger(month) ? month : now.getMonth() + 1;
+
+      if (resolvedMonth < 1 || resolvedMonth > 12) {
+        throw new BadRequestError('month debe estar entre 1 y 12', 'STATS_MONTH_INVALID');
+      }
+
+      if (resolvedYear < 2000 || resolvedYear > 2100) {
+        throw new BadRequestError('year fuera de rango permitido', 'STATS_YEAR_INVALID');
+      }
+
+      return this.pistaRepository.obtenerActividadMensualEscalador(
+        escalador.id,
+        resolvedYear,
+        resolvedMonth
+      );
+    } catch (error) {
+      if (error instanceof AppError) {
+        throw error;
+      }
+
+      throw new InternalServerError(
+        'Error al obtener actividad mensual del escalador',
+        'ESCALADOR_STATS_ACTIVIDAD_FETCH_FAILED',
+        error
+      );
+    }
+  }
+}
+
+export default ObtenerActividadMensualEscalador;

--- a/apps/backend/src/application/escaladores/obtenerResumenEstadisticasEscalador.js
+++ b/apps/backend/src/application/escaladores/obtenerResumenEstadisticasEscalador.js
@@ -1,0 +1,36 @@
+import {
+  AppError,
+  InternalServerError,
+  NotFoundError,
+} from '../../domain/sharedObjects/AppError.js';
+
+class ObtenerResumenEstadisticasEscalador {
+  constructor(escaladorRepository, pistaRepository) {
+    this.escaladorRepository = escaladorRepository;
+    this.pistaRepository = pistaRepository;
+  }
+
+  async execute({ apodo }) {
+    try {
+      const escalador = await this.escaladorRepository.encontrarPorApodo(apodo);
+
+      if (!escalador) {
+        throw new NotFoundError('Escalador no encontrado', 'ESCALADOR_NOT_FOUND');
+      }
+
+      return this.pistaRepository.obtenerResumenEstadisticasEscalador(escalador.id);
+    } catch (error) {
+      if (error instanceof AppError) {
+        throw error;
+      }
+
+      throw new InternalServerError(
+        'Error al obtener resumen de estadisticas del escalador',
+        'ESCALADOR_STATS_RESUMEN_FETCH_FAILED',
+        error
+      );
+    }
+  }
+}
+
+export default ObtenerResumenEstadisticasEscalador;

--- a/apps/backend/src/application/escaladores/obtenerTiposEstadisticasEscalador.js
+++ b/apps/backend/src/application/escaladores/obtenerTiposEstadisticasEscalador.js
@@ -1,0 +1,36 @@
+import {
+  AppError,
+  InternalServerError,
+  NotFoundError,
+} from '../../domain/sharedObjects/AppError.js';
+
+class ObtenerTiposEstadisticasEscalador {
+  constructor(escaladorRepository, pistaRepository) {
+    this.escaladorRepository = escaladorRepository;
+    this.pistaRepository = pistaRepository;
+  }
+
+  async execute({ apodo }) {
+    try {
+      const escalador = await this.escaladorRepository.encontrarPorApodo(apodo);
+
+      if (!escalador) {
+        throw new NotFoundError('Escalador no encontrado', 'ESCALADOR_NOT_FOUND');
+      }
+
+      return this.pistaRepository.obtenerTiposEstadisticasEscalador(escalador.id);
+    } catch (error) {
+      if (error instanceof AppError) {
+        throw error;
+      }
+
+      throw new InternalServerError(
+        'Error al obtener estadisticas por tipo de ruta del escalador',
+        'ESCALADOR_STATS_TIPOS_FETCH_FAILED',
+        error
+      );
+    }
+  }
+}
+
+export default ObtenerTiposEstadisticasEscalador;

--- a/apps/backend/src/domain/pistas/pistaRepository.js
+++ b/apps/backend/src/domain/pistas/pistaRepository.js
@@ -27,6 +27,14 @@ class PistaRepository {
   async obtenerEstado(idPista, idEscalador) {
     throw new Error('Método "obtenerEstado" no implementado');
   }
+
+  async obtenerResumenEstadisticasEscalador(idEscalador) {
+    throw new Error('Método "obtenerResumenEstadisticasEscalador" no implementado');
+  }
+
+  async obtenerTiposEstadisticasEscalador(idEscalador) {
+    throw new Error('Método "obtenerTiposEstadisticasEscalador" no implementado');
+  }
 }
 
 export default PistaRepository;

--- a/apps/backend/src/domain/pistas/pistaRepository.js
+++ b/apps/backend/src/domain/pistas/pistaRepository.js
@@ -35,6 +35,10 @@ class PistaRepository {
   async obtenerTiposEstadisticasEscalador(idEscalador) {
     throw new Error('Método "obtenerTiposEstadisticasEscalador" no implementado');
   }
+
+  async obtenerActividadMensualEscalador(idEscalador, year, month) {
+    throw new Error('Método "obtenerActividadMensualEscalador" no implementado');
+  }
 }
 
 export default PistaRepository;

--- a/apps/backend/src/infrastructure/container.js
+++ b/apps/backend/src/infrastructure/container.js
@@ -32,6 +32,8 @@ import ValidarApodoEscalador from '../application/escaladores/validarApodoEscala
 import ValidarCorreoEscalador from '../application/escaladores/validarCorreoEscalador.js';
 import ActualizarDescripcionEscalador from '../application/escaladores/actualizarDescripcionEscalador.js';
 import CambiarApodoEscalador from '../application/escaladores/cambiarApodoEscalador.js';
+import ObtenerResumenEstadisticasEscalador from '../application/escaladores/obtenerResumenEstadisticasEscalador.js';
+import ObtenerTiposEstadisticasEscalador from '../application/escaladores/obtenerTiposEstadisticasEscalador.js';
 
 import CrearPista from '../application/pistas/crearPista.js';
 import ActualizarPista from '../application/pistas/actualizarPista.js';
@@ -112,6 +114,13 @@ async function inicializarContainer() {
     escaladorRepository,
     tokenService
   );
+  const obtenerResumenEstadisticasUseCase =
+    new ObtenerResumenEstadisticasEscalador(
+      escaladorRepository,
+      pistaRepository
+    );
+  const obtenerTiposEstadisticasUseCase =
+    new ObtenerTiposEstadisticasEscalador(escaladorRepository, pistaRepository);
 
   const crearPistaUseCase = new CrearPista(
     pistaRepository,
@@ -171,6 +180,8 @@ async function inicializarContainer() {
     validarCorreo: validarCorreoUseCase,
     actualizarDescripcion: actualizarDescripcionUseCase,
     cambiarApodo: cambiarApodoUseCase,
+    obtenerResumenEstadisticas: obtenerResumenEstadisticasUseCase,
+    obtenerTiposEstadisticas: obtenerTiposEstadisticasUseCase,
   };
   const pistaUseCases = {
     crear: crearPistaUseCase,

--- a/apps/backend/src/infrastructure/container.js
+++ b/apps/backend/src/infrastructure/container.js
@@ -34,6 +34,7 @@ import ActualizarDescripcionEscalador from '../application/escaladores/actualiza
 import CambiarApodoEscalador from '../application/escaladores/cambiarApodoEscalador.js';
 import ObtenerResumenEstadisticasEscalador from '../application/escaladores/obtenerResumenEstadisticasEscalador.js';
 import ObtenerTiposEstadisticasEscalador from '../application/escaladores/obtenerTiposEstadisticasEscalador.js';
+import ObtenerActividadMensualEscalador from '../application/escaladores/obtenerActividadMensualEscalador.js';
 
 import CrearPista from '../application/pistas/crearPista.js';
 import ActualizarPista from '../application/pistas/actualizarPista.js';
@@ -121,6 +122,8 @@ async function inicializarContainer() {
     );
   const obtenerTiposEstadisticasUseCase =
     new ObtenerTiposEstadisticasEscalador(escaladorRepository, pistaRepository);
+  const obtenerActividadMensualUseCase =
+    new ObtenerActividadMensualEscalador(escaladorRepository, pistaRepository);
 
   const crearPistaUseCase = new CrearPista(
     pistaRepository,
@@ -182,6 +185,7 @@ async function inicializarContainer() {
     cambiarApodo: cambiarApodoUseCase,
     obtenerResumenEstadisticas: obtenerResumenEstadisticasUseCase,
     obtenerTiposEstadisticas: obtenerTiposEstadisticasUseCase,
+    obtenerActividadMensual: obtenerActividadMensualUseCase,
   };
   const pistaUseCases = {
     crear: crearPistaUseCase,

--- a/apps/backend/src/infrastructure/db/postgres/migrations/20260412011635-escalapista-maneja-fechas.js
+++ b/apps/backend/src/infrastructure/db/postgres/migrations/20260412011635-escalapista-maneja-fechas.js
@@ -1,0 +1,37 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+export default {
+  async up (queryInterface, Sequelize) {
+    await queryInterface.addColumn('EscalaPista', 'FechaCompletado', {
+      type: Sequelize.DATE,
+      allowNull: true,
+      defaultValue: null,
+    });
+
+    const [columns] = await queryInterface.sequelize.query(`
+      SELECT column_name
+      FROM information_schema.columns
+      WHERE table_schema = 'public'
+        AND table_name = 'EscalaPista'
+        AND column_name IN ('createdAt', 'FechaCreacion')
+    `);
+
+    const sourceColumn = Array.isArray(columns) && columns.length > 0
+      ? columns[0].column_name
+      : null;
+
+    const sourceExpr = sourceColumn ? `"${sourceColumn}"` : 'NOW()';
+
+    await queryInterface.sequelize.query(`
+      UPDATE "EscalaPista"
+      SET "FechaCompletado" = COALESCE(${sourceExpr}, NOW())
+      WHERE "Estado" IN ('flash', 'completado')
+        AND "FechaCompletado" IS NULL
+    `);
+  },
+
+  async down (queryInterface, Sequelize) {
+    await queryInterface.removeColumn('EscalaPista', 'FechaCompletado');
+  }
+};

--- a/apps/backend/src/infrastructure/db/postgres/models/escalaPistaModel.js
+++ b/apps/backend/src/infrastructure/db/postgres/models/escalaPistaModel.js
@@ -35,6 +35,11 @@ export default (sequelize, DataTypes) => {
         allowNull: false,
         field: 'Estado',
       },
+      fechaCompletado: {
+        type: DataTypes.DATE,
+        allowNull: true,
+        field: 'FechaCompletado',
+      },
     },
     {
       sequelize,

--- a/apps/backend/src/infrastructure/repositories/pistaRepositoryPostgres.js
+++ b/apps/backend/src/infrastructure/repositories/pistaRepositoryPostgres.js
@@ -72,6 +72,10 @@ class PistaRepositoryPostgres extends pistaRepository {
 
   async cambiarEstado(idPista, idEscalador, nuevoEstado) {
     try {
+      const fechaCompletado = ['flash', 'completado'].includes(nuevoEstado)
+        ? new Date()
+        : null;
+
       const pistaModel = await this.PistaModel.findByPk(idPista, {
         include: [
           {
@@ -93,11 +97,17 @@ class PistaRepositoryPostgres extends pistaRepository {
       if (pistaModel.escaladores && pistaModel.escaladores.length > 0) {
         // Si existe, actualizar el estado
         const escaladorData = pistaModel.escaladores[0];
-        await escaladorData.EscalaPista.update({ estado: nuevoEstado });
+        await escaladorData.EscalaPista.update({
+          estado: nuevoEstado,
+          fechaCompletado,
+        });
       } else {
         // Si no existe, crear la relación
         await pistaModel.addEscaladores(idEscalador, {
-          through: { estado: nuevoEstado },
+          through: {
+            estado: nuevoEstado,
+            fechaCompletado,
+          },
         });
       }
     } catch (error) {
@@ -355,16 +365,17 @@ class PistaRepositoryPostgres extends pistaRepository {
       const rows = await this.PistaModel.sequelize.query(
         `
           SELECT
-            EXTRACT(DAY FROM p."FechaCreacion")::int AS dia,
+            DATE(ep."FechaCompletado") AS "fechaCompletado",
+            EXTRACT(DAY FROM ep."FechaCompletado")::int AS dia,
             COUNT(*)::int AS rutas
-          FROM "Pistas" p
-          INNER JOIN "EscalaPista" ep ON ep."IDPista" = p."IDPista"
+          FROM "EscalaPista" ep
           WHERE ep."IDEscalador" = :idEscalador
             AND ep."Estado" IN ('flash', 'completado')
-            AND p."FechaCreacion" >= :startDate
-            AND p."FechaCreacion" < :endDate
-          GROUP BY dia
-          ORDER BY dia ASC
+            AND ep."FechaCompletado" IS NOT NULL
+            AND ep."FechaCompletado" >= :startDate
+            AND ep."FechaCompletado" < :endDate
+          GROUP BY DATE(ep."FechaCompletado"), EXTRACT(DAY FROM ep."FechaCompletado")
+          ORDER BY DATE(ep."FechaCompletado") ASC
         `,
         {
           replacements: { idEscalador, startDate, endDate },
@@ -373,6 +384,7 @@ class PistaRepositoryPostgres extends pistaRepository {
       );
 
       const actividadMensual = rows.map((row) => ({
+        fechaCompletado: row.fechaCompletado,
         dia: Number(row.dia),
         rutas: Number(row.rutas) || 0,
       }));

--- a/apps/backend/src/infrastructure/repositories/pistaRepositoryPostgres.js
+++ b/apps/backend/src/infrastructure/repositories/pistaRepositoryPostgres.js
@@ -1,3 +1,4 @@
+import { fn, col } from 'sequelize';
 import pistaRepository from '../../domain/pistas/pistaRepository.js';
 import Pista from '../../domain/pistas/Pista.js';
 import { NotFoundError, ValidationError } from '../../domain/sharedObjects/AppError.js';
@@ -223,6 +224,125 @@ class PistaRepositoryPostgres extends pistaRepository {
       throw mapRepositoryError(error, {
         fallbackMessage: 'Error al obtener estado de pista',
         internalCode: 'PISTA_GET_STATE_DB_FAILED',
+      });
+    }
+  }
+
+  async obtenerResumenEstadisticasEscalador(idEscalador) {
+    try {
+      const escalaPistaModel = this.PistaModel.sequelize.models.EscalaPista;
+      const filas = await escalaPistaModel.findAll({
+        where: { idEscalador },
+        attributes: [
+          [col('Estado'), 'estado'],
+          [fn('COUNT', col('Estado')), 'total'],
+        ],
+        group: [col('Estado')],
+        raw: true,
+      });
+
+      const totales = filas.reduce(
+        (acc, fila) => {
+          const estado = fila.estado;
+          const total = Number(fila.total) || 0;
+          if (estado === 'flash') {
+            acc.totalFlash = total;
+          } else if (estado === 'completado') {
+            acc.totalCompletado = total;
+          } else if (estado === 'proyecto') {
+            acc.totalProyecto = total;
+          }
+          return acc;
+        },
+        {
+          totalFlash: 0,
+          totalCompletado: 0,
+          totalProyecto: 0,
+        }
+      );
+
+      const totalRutas = totales.totalFlash + totales.totalCompletado;
+      const porcentajeFlash =
+        totalRutas > 0 ? (totales.totalFlash / totalRutas) * 100 : 0;
+ 
+      return {
+        totalRutas,
+        totalFlash: totales.totalFlash,
+        totalCompletado: totales.totalCompletado,
+        totalProyecto: totales.totalProyecto,
+        porcentajeFlash,
+      };
+    } catch (error) {
+      throw mapRepositoryError(error, {
+        fallbackMessage: 'Error al obtener resumen de estadisticas del escalador',
+        internalCode: 'PISTA_STATS_RESUMEN_DB_FAILED',
+      });
+    }
+  }
+
+  async obtenerTiposEstadisticasEscalador(idEscalador) {
+    try {
+      const filas = await this.PistaModel.findAll({
+        attributes: [
+          'tipo',
+          [fn('COUNT', col('Pista.IDPista')), 'total'],
+        ],
+        include: [
+          {
+            association: 'escaladores',
+            attributes: [],
+            through: {
+              attributes: [],
+              where: {
+                idEscalador,
+                estado: ['flash', 'completado'],
+              },
+            },
+            required: true,
+          },
+        ],
+        group: [col('Pista.Tipo')],
+        raw: true,
+      });
+
+      const totales = filas.reduce(
+        (acc, fila) => {
+          const tipo = fila.tipo;
+          const total = Number(fila.total) || 0;
+
+          if (tipo === 'boulder') {
+            acc.totalBloques = total;
+          } else if (tipo === 'via') {
+            acc.totalVias = total;
+          }
+
+          return acc;
+        },
+        {
+          totalBloques: 0,
+          totalVias: 0,
+        }
+      );
+
+      const totalRutas = totales.totalBloques + totales.totalVias;
+      const porcentajeBloques =
+        totalRutas > 0 ? (totales.totalBloques / totalRutas) * 100 : 0;
+      const porcentajeVias =
+        totalRutas > 0 ? (totales.totalVias / totalRutas) * 100 : 0;
+
+      return {
+        totalBloques: totales.totalBloques,
+        totalVias: totales.totalVias,
+        porcentajeBloques,
+        porcentajeVias,
+        favoritaTexto:
+          totales.totalBloques >= totales.totalVias ? 'Bloque' : 'Via',
+      };
+    } catch (error) {
+      throw mapRepositoryError(error, {
+        fallbackMessage:
+          'Error al obtener distribucion por tipo de rutas del escalador',
+        internalCode: 'PISTA_STATS_TIPOS_DB_FAILED',
       });
     }
   }

--- a/apps/backend/src/infrastructure/repositories/pistaRepositoryPostgres.js
+++ b/apps/backend/src/infrastructure/repositories/pistaRepositoryPostgres.js
@@ -1,4 +1,4 @@
-import { fn, col } from 'sequelize';
+import { fn, col, QueryTypes } from 'sequelize';
 import pistaRepository from '../../domain/pistas/pistaRepository.js';
 import Pista from '../../domain/pistas/Pista.js';
 import { NotFoundError, ValidationError } from '../../domain/sharedObjects/AppError.js';
@@ -343,6 +343,49 @@ class PistaRepositoryPostgres extends pistaRepository {
         fallbackMessage:
           'Error al obtener distribucion por tipo de rutas del escalador',
         internalCode: 'PISTA_STATS_TIPOS_DB_FAILED',
+      });
+    }
+  }
+
+  async obtenerActividadMensualEscalador(idEscalador, year, month) {
+    try {
+      const startDate = new Date(Date.UTC(year, month - 1, 1, 0, 0, 0));
+      const endDate = new Date(Date.UTC(year, month, 1, 0, 0, 0));
+
+      const rows = await this.PistaModel.sequelize.query(
+        `
+          SELECT
+            EXTRACT(DAY FROM p."FechaCreacion")::int AS dia,
+            COUNT(*)::int AS rutas
+          FROM "Pistas" p
+          INNER JOIN "EscalaPista" ep ON ep."IDPista" = p."IDPista"
+          WHERE ep."IDEscalador" = :idEscalador
+            AND ep."Estado" IN ('flash', 'completado')
+            AND p."FechaCreacion" >= :startDate
+            AND p."FechaCreacion" < :endDate
+          GROUP BY dia
+          ORDER BY dia ASC
+        `,
+        {
+          replacements: { idEscalador, startDate, endDate },
+          type: QueryTypes.SELECT,
+        }
+      );
+
+      const actividadMensual = rows.map((row) => ({
+        dia: Number(row.dia),
+        rutas: Number(row.rutas) || 0,
+      }));
+
+      return {
+        year,
+        month,
+        actividadMensual,
+      };
+    } catch (error) {
+      throw mapRepositoryError(error, {
+        fallbackMessage: 'Error al obtener actividad mensual del escalador',
+        internalCode: 'PISTA_STATS_ACTIVIDAD_MENSUAL_DB_FAILED',
       });
     }
   }

--- a/apps/backend/src/interfaces/http/controllers/escaladorController.js
+++ b/apps/backend/src/interfaces/http/controllers/escaladorController.js
@@ -48,6 +48,54 @@ class EscaladorController {
     }
   }
 
+  async obtenerResumenEstadisticas(req, res, next) {
+    try {
+      const apodo = req.user.apodo;
+      const resumen = await this.useCases.obtenerResumenEstadisticas.execute({
+        apodo,
+      });
+      res.status(200).json(resumen);
+    } catch (error) {
+      return next(error);
+    }
+  }
+
+  async obtenerTiposEstadisticas(req, res, next) {
+    try {
+      const apodo = req.user.apodo;
+      const tipos = await this.useCases.obtenerTiposEstadisticas.execute({
+        apodo,
+      });
+      res.status(200).json(tipos);
+    } catch (error) {
+      return next(error);
+    }
+  }
+
+  async obtenerResumenEstadisticasPublico(req, res, next) {
+    try {
+      const { apodo } = req.params;
+      const resumen = await this.useCases.obtenerResumenEstadisticas.execute({
+        apodo,
+      });
+      res.status(200).json(resumen);
+    } catch (error) {
+      return next(error);
+    }
+  }
+
+  async obtenerTiposEstadisticasPublico(req, res, next) {
+    try {
+      const { apodo } = req.params;
+      const tipos = await this.useCases.obtenerTiposEstadisticas.execute({
+        apodo,
+      });
+      res.status(200).json(tipos);
+    } catch (error) {
+      return next(error);
+    }
+  }
+
   async suscribirse(req, res, next) {
     try {
       const escaladorApodo = req.user.apodo; // Asumiendo que el middleware verifyToken añade escaladorId al req

--- a/apps/backend/src/interfaces/http/controllers/escaladorController.js
+++ b/apps/backend/src/interfaces/http/controllers/escaladorController.js
@@ -72,6 +72,22 @@ class EscaladorController {
     }
   }
 
+  async obtenerActividadMensual(req, res, next) {
+    try {
+      const apodo = req.user.apodo;
+      const year = req.query.year ? Number(req.query.year) : undefined;
+      const month = req.query.month ? Number(req.query.month) : undefined;
+      const actividad = await this.useCases.obtenerActividadMensual.execute({
+        apodo,
+        year,
+        month,
+      });
+      res.status(200).json(actividad);
+    } catch (error) {
+      return next(error);
+    }
+  }
+
   async obtenerResumenEstadisticasPublico(req, res, next) {
     try {
       const { apodo } = req.params;
@@ -91,6 +107,22 @@ class EscaladorController {
         apodo,
       });
       res.status(200).json(tipos);
+    } catch (error) {
+      return next(error);
+    }
+  }
+
+  async obtenerActividadMensualPublico(req, res, next) {
+    try {
+      const { apodo } = req.params;
+      const year = req.query.year ? Number(req.query.year) : undefined;
+      const month = req.query.month ? Number(req.query.month) : undefined;
+      const actividad = await this.useCases.obtenerActividadMensual.execute({
+        apodo,
+        year,
+        month,
+      });
+      res.status(200).json(actividad);
     } catch (error) {
       return next(error);
     }

--- a/apps/backend/src/interfaces/http/routes/escaladoresRoutes.js
+++ b/apps/backend/src/interfaces/http/routes/escaladoresRoutes.js
@@ -234,6 +234,65 @@ router.get('/perfil', verifyToken, (req, res, next) => {
 });
 
 /**
+ * GET /escaladores/stats/resumen
+ * Obtiene estadisticas resumidas del escalador autenticado.
+ *
+ * Requiere: Token JWT valido en header Authorization.
+ */
+router.get('/stats/resumen', verifyToken, (req, res, next) => {
+  escaladorController.obtenerResumenEstadisticas(req, res, next);
+});
+
+/**
+ * GET /escaladores/stats/tipos
+ * Obtiene distribucion por tipo de rutas escaladas del escalador autenticado.
+ *
+ * Requiere: Token JWT valido en header Authorization.
+ */
+router.get('/stats/tipos', verifyToken, (req, res, next) => {
+  escaladorController.obtenerTiposEstadisticas(req, res, next);
+});
+
+const statsPublicosPorApodoValidators = [
+  param('apodo')
+    .trim()
+    .notEmpty()
+    .withMessage('apodo es requerido')
+    .isLength({ min: 1, max: 20 })
+    .withMessage('apodo debe tener entre 1 y 20 caracteres')
+    .matches(/^[a-zA-Z0-9_-]+$/)
+    .withMessage(
+      'apodo solo puede contener letras, numeros, guiones y guiones bajos'
+    ),
+];
+
+/**
+ * GET /escaladores/public/:apodo/stats/resumen
+ * Obtiene estadisticas resumidas publicas de un escalador por apodo.
+ */
+router.get(
+  '/public/:apodo/stats/resumen',
+  statsPublicosPorApodoValidators,
+  validate,
+  (req, res, next) => {
+    escaladorController.obtenerResumenEstadisticasPublico(req, res, next);
+  }
+);
+
+/**
+ * GET /escaladores/public/:apodo/stats/tipos
+ * Obtiene distribucion de tipos de rutas publicas de un escalador por apodo.
+ */
+router.get(
+  '/public/:apodo/stats/tipos',
+  statsPublicosPorApodoValidators,
+  validate,
+  (req, res, next) => {
+    escaladorController.obtenerTiposEstadisticasPublico(req, res, next);
+  }
+);
+
+/**
  * PUT /escaladores/actualizarDescripcion
  * Actualiza la descripcion del escalador autenticado
  *

--- a/apps/backend/src/interfaces/http/routes/escaladoresRoutes.js
+++ b/apps/backend/src/interfaces/http/routes/escaladoresRoutes.js
@@ -1,5 +1,5 @@
 import express from 'express';
-import { body, param } from 'express-validator';
+import { body, param, query } from 'express-validator';
 import validate from '../middlewares/validate.js';
 import verifyToken from '../middlewares/verifyToken.js';
 import uploadImages, {
@@ -253,6 +253,33 @@ router.get('/stats/tipos', verifyToken, (req, res, next) => {
   escaladorController.obtenerTiposEstadisticas(req, res, next);
 });
 
+const actividadMensualValidators = [
+  query('year')
+    .optional()
+    .toInt()
+    .isInt({ min: 2000, max: 2100 })
+    .withMessage('year debe ser un entero entre 2000 y 2100'),
+  query('month')
+    .optional()
+    .toInt()
+    .isInt({ min: 1, max: 12 })
+    .withMessage('month debe ser un entero entre 1 y 12'),
+];
+
+/**
+ * GET /escaladores/stats/actividad-mensual
+ * Obtiene actividad mensual del escalador autenticado para el mes y anio solicitados.
+ */
+router.get(
+  '/stats/actividad-mensual',
+  verifyToken,
+  actividadMensualValidators,
+  validate,
+  (req, res, next) => {
+    escaladorController.obtenerActividadMensual(req, res, next);
+  }
+);
+
 const statsPublicosPorApodoValidators = [
   param('apodo')
     .trim()
@@ -289,6 +316,20 @@ router.get(
   validate,
   (req, res, next) => {
     escaladorController.obtenerTiposEstadisticasPublico(req, res, next);
+  }
+);
+
+/**
+ * GET /escaladores/public/:apodo/stats/actividad-mensual
+ * Obtiene actividad mensual publica de un escalador por apodo.
+ */
+router.get(
+  '/public/:apodo/stats/actividad-mensual',
+  statsPublicosPorApodoValidators,
+  actividadMensualValidators,
+  validate,
+  (req, res, next) => {
+    escaladorController.obtenerActividadMensualPublico(req, res, next);
   }
 );
 

--- a/apps/frontend/src/css/global.css
+++ b/apps/frontend/src/css/global.css
@@ -54,7 +54,9 @@ body {
   line-height: 1.3;
   opacity: 0;
   transform: translateY(6px);
-  transition: opacity 0.2s ease, transform 0.2s ease;
+  transition:
+    opacity 0.2s ease,
+    transform 0.2s ease;
   pointer-events: auto;
 }
 
@@ -82,12 +84,12 @@ body {
 }
 
 /* Contenido centrado con ancho máximo */
-#app-container.app-vertical-layout>.app-content {
+#app-container.app-vertical-layout > .app-content {
   width: 100%;
   max-width: var(--app-max-width);
 }
 
-#app-container.app-vertical-layout>.app-content.app-shell {
+#app-container.app-vertical-layout > .app-content.app-shell {
   height: 100dvh;
 }
 
@@ -97,20 +99,20 @@ body {
     padding: 0;
   }
 
-  #app-container.app-vertical-layout>.app-content {
+  #app-container.app-vertical-layout > .app-content {
     max-width: 100%;
   }
 
   /* Cards a pantalla completa en móvil (solo la card principal) */
-  #app-container.app-vertical-layout>.app-content.app-shell {
+  #app-container.app-vertical-layout > .app-content.app-shell {
     border-radius: 0 !important;
     border-left: none !important;
     border-right: none !important;
     min-height: 100dvh;
   }
 
-  #app-container.app-vertical-layout>.app-content.app-shell>.card-header,
-  #app-container.app-vertical-layout>.app-content.app-shell>.card-footer {
+  #app-container.app-vertical-layout > .app-content.app-shell > .card-header,
+  #app-container.app-vertical-layout > .app-content.app-shell > .card-footer {
     border-radius: 0 !important;
   }
 }
@@ -134,7 +136,9 @@ body {
    ======================================== */
 .zona-card {
   cursor: pointer;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  transition:
+    transform 0.2s ease,
+    box-shadow 0.2s ease;
 }
 
 .zona-card:hover {
@@ -204,10 +208,12 @@ body {
   left: -100%;
   width: 100%;
   height: 100%;
-  background: linear-gradient(90deg,
-      transparent,
-      rgba(255, 255, 255, 0.4),
-      transparent);
+  background: linear-gradient(
+    90deg,
+    transparent,
+    rgba(255, 255, 255, 0.4),
+    transparent
+  );
   animation: shimmer 2s infinite;
 }
 
@@ -274,7 +280,6 @@ body {
   font-size: 0.5rem;
   font-weight: bold;
 }
-
 
 /* ========================================
    Mapa SVG interactivo de zonas
@@ -425,7 +430,7 @@ body {
   background-color: #dee2e6;
 }
 
-.perfil-photo-modal-body>.perfil-photo-section-divider {
+.perfil-photo-modal-body > .perfil-photo-section-divider {
   margin-bottom: 0.5rem;
 }
 
@@ -505,7 +510,6 @@ body {
   margin-bottom: 1.5rem;
 }
 
-
 .perfil-apodo-view,
 .perfil-descripcion-view {
   display: flex;
@@ -525,6 +529,198 @@ body {
   align-items: stretch;
   width: max-content;
   max-width: 100%;
+}
+
+.perfil-estadisticas-view {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  width: 100%;
+  padding: 0 16px;
+  box-sizing: border-box;
+  text-align: left;
+  color: #212529;
+}
+
+.perfil-stats-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.perfil-stats-title {
+  margin: 0;
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #2c2c2c;
+}
+
+.perfil-stats-card {
+  background: #f8f9fa;
+  border: 1px solid #d7d7d7;
+  border-radius: 16px;
+  padding: 14px;
+  box-shadow:
+    0 8px 12px rgba(0, 0, 0, 0.25),
+    0 4px 6px rgba(0, 0, 0, 0.20);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.perfil-stats-badges,
+.perfil-stats-choices {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.perfil-stats-badge {
+  border-radius: 14px;
+  padding: 10px 12px;
+  min-width: 0;
+  text-align: center;
+  border: 1px solid transparent;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.perfil-stats-badge-value {
+  font-size: 1.1rem;
+  font-weight: 700;
+}
+
+.perfil-stats-badge-label {
+  font-size: 0.75rem;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+.perfil-stats-badge.is-completed {
+  background: #e6f4ea;
+  border-color: #7bcf9a;
+  color: #116530;
+}
+
+.perfil-stats-badge.is-flash {
+  background: #f0f0c9;
+  border-color: #b6b06a;
+  color: #5f5b1a;
+}
+
+.perfil-stats-pill {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  border-radius: 999px;
+  padding: 8px 12px;
+  border: 1px solid transparent;
+  font-weight: 600;
+  min-width: 0;
+}
+
+.perfil-stats-pill-value {
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-weight: 700;
+  background: #ffffff;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+}
+
+.perfil-stats-pill.is-bloque {
+  background: #e5f6ea;
+  border-color: #7dcf9a;
+  color: #136a35;
+}
+
+.perfil-stats-pill.is-via {
+  background: #ffe7f1;
+  border-color: #f2a7c7;
+  color: #8c2f54;
+}
+
+.perfil-stats-text {
+  margin: 0;
+  color: #4a4a4a;
+  font-size: 0.9rem;
+  line-height: 1.35;
+}
+
+.perfil-stats-bar {
+  position: relative;
+  height: 12px;
+  background: #e2e2e2;
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.perfil-stats-bar.is-split {
+  display: flex;
+}
+
+.perfil-stats-bar.is-split .perfil-stats-bar-fill {
+  position: static;
+}
+
+.perfil-stats-bar-fill {
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  border-radius: 999px;
+}
+
+.perfil-stats-bar-fill.is-completed {
+  background: #1f9d4a;
+}
+
+.perfil-stats-bar-fill.is-flash {
+  background: #a6a622;
+}
+
+.perfil-stats-bar-fill.is-bloque {
+  background: #28a861;
+}
+
+.perfil-stats-bar-fill.is-via {
+  background: #e35b93;
+}
+
+.perfil-stats-bar-labels {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.75rem;
+  color: #6c757d;
+}
+
+@media (max-width: 480px) {
+  .perfil-stats-badges,
+  .perfil-stats-choices {
+    justify-content: center;
+  }
+
+  .perfil-stats-card {
+    text-align: center;
+  }
+}
+
+@media (max-width: 350px) {
+  .perfil-stats-badges,
+  .perfil-stats-choices {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .perfil-stats-card {
+    padding: 12px;
+  }
+
+  .perfil-stats-title {
+    text-align: center;
+  }
 }
 
 .section-divider {
@@ -549,9 +745,6 @@ body {
   height: 1px;
   background-color: #cbcbcb;
 }
-
-
-
 
 .perfil-correo-view,
 .perfil-foto-view {
@@ -647,7 +840,10 @@ body {
   border-radius: 50%;
   object-fit: cover;
   border: 2px solid #ced4da;
-  transition: border-color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+  transition:
+    border-color 0.2s ease,
+    transform 0.2s ease,
+    box-shadow 0.2s ease;
 }
 
 .perfil-photo-option:hover .perfil-photo-option-image {

--- a/apps/frontend/src/css/global.css
+++ b/apps/frontend/src/css/global.css
@@ -615,11 +615,11 @@ body {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 8px;
+  gap: 2px;
   border-radius: 999px;
-  padding: 8px 12px;
+  padding: 8px 6px;
   border: 1px solid transparent;
-  font-weight: 600;
+  font-weight: 450;
   min-width: 0;
 }
 

--- a/apps/frontend/src/css/global.css
+++ b/apps/frontend/src/css/global.css
@@ -545,7 +545,7 @@ body {
 .perfil-stats-section {
   display: flex;
   flex-direction: column;
-  gap: 0.6rem;
+  gap: 1.15rem;
 }
 
 .perfil-stats-title {
@@ -702,6 +702,27 @@ body {
   position: relative;
 }
 
+.perfil-heatmap-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.perfil-heatmap-month {
+  font-weight: 700;
+  font-size: 1rem;
+  color: #1f1f1f;
+  text-transform: capitalize;
+}
+
+.perfil-heatmap-subtitle {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #6c757d;
+}
+
 .perfil-heatmap-weekdays {
   display: grid;
   grid-template-columns: repeat(7, minmax(0, 1fr));
@@ -771,6 +792,74 @@ body {
   border-radius: 3px;
 }
 
+.perfil-monthly-summary {
+  gap: 0.9rem;
+}
+
+.perfil-monthly-metrics {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.perfil-monthly-metric {
+  background: #ffffff;
+  border: 1px solid #e1e1e1;
+  border-radius: 12px;
+  padding: 10px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  text-align: center;
+}
+
+.perfil-monthly-label {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #6c757d;
+}
+
+.perfil-monthly-value {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: #1f1f1f;
+}
+
+.perfil-monthly-chart {
+  display: grid;
+  min-height: 90px;
+  padding: 8px 6px 2px;
+  background: #ffffff;
+  border: 1px solid #e1e1e1;
+  border-radius: 12px;
+  width: 100%;
+  margin: 0;
+}
+
+.perfil-monthly-bar {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 6px;
+  height: 100%;
+  width: 100%;
+}
+
+.perfil-monthly-bar-fill {
+  width: 100%;
+  max-width: 24px;
+  border-radius: 6px;
+  background: linear-gradient(180deg, #f6a44a 0%, #d97924 100%);
+  min-height: 8px;
+}
+
+.perfil-monthly-bar-label {
+  font-size: 0.65rem;
+  color: #6c757d;
+}
+
 .perfil-heatmap-tooltip {
   position: absolute;
   left: 0;
@@ -820,6 +909,10 @@ body {
   .perfil-heatmap-weekdays,
   .perfil-heatmap-grid {
     gap: 4px;
+  }
+
+  .perfil-monthly-metrics {
+    grid-template-columns: minmax(0, 1fr);
   }
 }
 

--- a/apps/frontend/src/css/global.css
+++ b/apps/frontend/src/css/global.css
@@ -697,6 +697,101 @@ body {
   color: #6c757d;
 }
 
+.perfil-heatmap-card {
+  gap: 0.9rem;
+  position: relative;
+}
+
+.perfil-heatmap-weekdays {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: 6px;
+  font-size: 0.7rem;
+  color: #6c757d;
+  text-align: center;
+  letter-spacing: 0.02em;
+}
+
+.perfil-heatmap-grid {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: 6px;
+}
+
+.perfil-heatmap-day {
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  border-radius: 4px;
+  background: #e9ecef;
+  border: 1px solid #d5d5d5;
+}
+
+.perfil-heatmap-day:not(.is-empty) {
+  cursor: pointer;
+}
+
+.perfil-heatmap-day.is-empty {
+  background: transparent;
+  border-color: transparent;
+}
+
+.perfil-heatmap-day.is-low {
+  background: #ffd8b0;
+  border-color: #f4c08a;
+}
+
+.perfil-heatmap-day.is-mid {
+  background: #f4a261;
+  border-color: #e88b3d;
+}
+
+.perfil-heatmap-day.is-high {
+  background: #d97924;
+  border-color: #c86b17;
+}
+
+.perfil-heatmap-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px 16px;
+  align-items: center;
+  font-size: 0.75rem;
+  color: #6c757d;
+}
+
+.perfil-heatmap-legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.perfil-heatmap-legend-swatch {
+  width: 14px;
+  height: 14px;
+  border-radius: 3px;
+}
+
+.perfil-heatmap-tooltip {
+  position: absolute;
+  left: 0;
+  top: 0;
+  transform: translate(-50%, -100%);
+  padding: 6px 8px;
+  border-radius: 6px;
+  background: #1f1f1f;
+  color: #ffffff;
+  font-size: 0.75rem;
+  white-space: nowrap;
+  box-shadow: 0 6px 14px rgba(0, 0, 0, 0.25);
+  opacity: 0;
+  pointer-events: none;
+  z-index: 2;
+}
+
+.perfil-heatmap-tooltip.is-visible {
+  opacity: 1;
+}
+
 @media (max-width: 480px) {
   .perfil-stats-badges,
   .perfil-stats-choices {
@@ -720,6 +815,11 @@ body {
 
   .perfil-stats-title {
     text-align: center;
+  }
+
+  .perfil-heatmap-weekdays,
+  .perfil-heatmap-grid {
+    gap: 4px;
   }
 }
 

--- a/apps/frontend/src/js/components/escaladorStats.js
+++ b/apps/frontend/src/js/components/escaladorStats.js
@@ -1,0 +1,335 @@
+import { escapeHtml } from './formHelpers.js';
+
+const WEEKDAY_LABELS = Object.freeze(['L', 'M', 'X', 'J', 'V', 'S', 'D']);
+
+function toSafeCount(value) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return 0;
+  }
+
+  return Math.round(parsed);
+}
+
+function toSafePercentage(value) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return 0;
+  }
+
+  return parsed;
+}
+
+function formatPct(value) {
+  return `${toSafePercentage(value).toFixed(2)}%`;
+}
+
+function resolveHeatmapToneClass(count) {
+  if (count >= 5) {
+    return 'is-high';
+  }
+
+  if (count >= 3) {
+    return 'is-mid';
+  }
+
+  if (count >= 1) {
+    return 'is-low';
+  }
+
+  return 'is-zero';
+}
+
+function buildMonthlyActivityViewModel(actividadMensual = [], now = new Date()) {
+  const currentYear = now.getFullYear();
+  const currentMonth = now.getMonth();
+  const monthLabel = now.toLocaleString('es-ES', {
+    month: 'long',
+    year: 'numeric',
+  });
+  const monthTitle = monthLabel.charAt(0).toUpperCase() + monthLabel.slice(1);
+  const daysInMonth = new Date(currentYear, currentMonth + 1, 0).getDate();
+  const firstDayIndex = (new Date(currentYear, currentMonth, 1).getDay() + 6) % 7;
+  const totalHeatmapCells = Math.ceil((firstDayIndex + daysInMonth) / 7) * 7;
+
+  const actividadPorDia = actividadMensual.reduce((acc, item) => {
+    const dia = Number(item?.dia);
+    const rutas = Number(item?.rutas);
+
+    if (Number.isInteger(dia) && dia > 0 && dia <= daysInMonth) {
+      acc[dia] = Number.isFinite(rutas) && rutas > 0 ? Math.round(rutas) : 0;
+    }
+
+    return acc;
+  }, {});
+
+  const heatmapCells = Array.from({ length: totalHeatmapCells }, (_, index) => {
+    const dayNumber = index - firstDayIndex + 1;
+
+    if (dayNumber < 1 || dayNumber > daysInMonth) {
+      return null;
+    }
+
+    const count = actividadPorDia[dayNumber] || 0;
+    return {
+      day: dayNumber,
+      count,
+      toneClass: resolveHeatmapToneClass(count),
+    };
+  });
+
+  const heatmapCounts = heatmapCells.map((cell) => (cell ? cell.count : 0));
+  const totalMonthlyRoutes = heatmapCounts.reduce((acc, count) => acc + count, 0);
+  const activeDays = heatmapCells.filter((cell) => cell && cell.count > 0).length;
+  const avgRoutesPerActiveDay = activeDays ? totalMonthlyRoutes / activeDays : 0;
+  const weeklyTotals = [];
+
+  for (let i = 0; i < heatmapCounts.length; i += 7) {
+    weeklyTotals.push(heatmapCounts.slice(i, i + 7).reduce((acc, count) => acc + count, 0));
+  }
+
+  return {
+    monthTitle,
+    weekdayLabels: WEEKDAY_LABELS,
+    heatmapCells,
+    hasActivity: actividadMensual.length > 0,
+    totalMonthlyRoutes,
+    activeDays,
+    avgRoutesPerActiveDay,
+    weeklyTotals,
+  };
+}
+
+export function buildEscaladorStatsViewModel(estadisticas = {}, now = new Date()) {
+  const totalRutas = toSafeCount(estadisticas.totalRutas);
+  const totalFlash = toSafeCount(estadisticas.totalFlash);
+  const totalBloques = toSafeCount(estadisticas.totalBloques);
+  const totalVias = toSafeCount(estadisticas.totalVias);
+  const rutasFlashPct = totalRutas > 0 ? (totalFlash / totalRutas) * 100 : 0;
+  const bloquesPct = totalRutas > 0 ? (totalBloques / totalRutas) * 100 : 0;
+  const viasPct = totalRutas > 0 ? (totalVias / totalRutas) * 100 : 0;
+  const favoritaTextoRaw =
+    typeof estadisticas.favoritaTexto === 'string' && estadisticas.favoritaTexto.trim()
+      ? estadisticas.favoritaTexto.trim()
+      : totalBloques >= totalVias
+        ? 'Bloque'
+        : 'Via';
+  const actividadMensual = Array.isArray(estadisticas.actividadMensual)
+    ? estadisticas.actividadMensual
+    : [];
+
+  return {
+    totals: {
+      totalRutas,
+      totalFlash,
+      totalBloques,
+      totalVias,
+      rutasFlashPct,
+      bloquesPct,
+      viasPct,
+      favoritaTexto: escapeHtml(favoritaTextoRaw),
+    },
+    monthly: buildMonthlyActivityViewModel(actividadMensual, now),
+  };
+}
+
+export function renderStatsSection({ title, content }) {
+  return `
+    <div class="perfil-stats-section">
+      <p class="perfil-stats-title">${escapeHtml(title || '')}</p>
+      ${content}
+    </div>
+  `;
+}
+
+export function renderTotalRoutesStatsCard(totals = {}) {
+  return `
+    <div class="perfil-stats-card">
+      <div class="perfil-stats-badges">
+        <div class="perfil-stats-badge is-completed">
+          <span class="perfil-stats-badge-value">${totals.totalRutas || 0}</span>
+          <span class="perfil-stats-badge-label">Completado</span>
+        </div>
+        <div class="perfil-stats-badge is-flash">
+          <span class="perfil-stats-badge-value">${totals.totalFlash || 0}</span>
+          <span class="perfil-stats-badge-label">Flash</span>
+        </div>
+      </div>
+      <p class="perfil-stats-text">
+        Has escalado un total de ${totals.totalRutas || 0} rutas, de las cuales ${totals.totalFlash || 0} han sido a la primera.
+      </p>
+      <div class="perfil-stats-bar">
+        <span class="perfil-stats-bar-fill is-completed" style="width: 100%;"></span>
+        <span class="perfil-stats-bar-fill is-flash" style="width: ${formatPct(totals.rutasFlashPct)};"></span>
+      </div>
+      <div class="perfil-stats-bar-labels">
+        <span>${formatPct(totals.rutasFlashPct)}</span>
+      </div>
+    </div>
+  `;
+}
+
+export function renderRouteTypesStatsCard(totals = {}) {
+  return `
+    <div class="perfil-stats-card">
+      <div class="perfil-stats-choices">
+        <div class="perfil-stats-pill is-bloque">
+          <span class="perfil-stats-pill-label">Bloques</span>
+          <span class="perfil-stats-pill-value">${totals.totalBloques || 0}</span>
+        </div>
+        <div class="perfil-stats-pill is-via">
+          <span class="perfil-stats-pill-label">Vias</span>
+          <span class="perfil-stats-pill-value">${totals.totalVias || 0}</span>
+        </div>
+      </div>
+      <p class="perfil-stats-text">Tu tipo de ruta favorita es el ${totals.favoritaTexto || 'Bloque'}.</p>
+      <div class="perfil-stats-bar is-split">
+        <span class="perfil-stats-bar-fill is-bloque" style="width: ${formatPct(totals.bloquesPct)};"></span>
+        <span class="perfil-stats-bar-fill is-via" style="width: ${formatPct(totals.viasPct)};"></span>
+      </div>
+      <div class="perfil-stats-bar-labels">
+        <span>${formatPct(totals.bloquesPct)}</span>
+        <span>${formatPct(totals.viasPct)}</span>
+      </div>
+    </div>
+  `;
+}
+
+export function renderMonthlyActivityCards(monthly = {}) {
+  const weeklyTotals = Array.isArray(monthly.weeklyTotals) ? monthly.weeklyTotals : [];
+  const maxWeeklyTotal = Math.max(1, ...weeklyTotals);
+  const weeklyBarsHtml = weeklyTotals
+    .map((total, index) => {
+      const heightPct = (total / maxWeeklyTotal) * 100;
+      return `
+        <div class="perfil-monthly-bar">
+          <span class="perfil-monthly-bar-fill" style="height: ${heightPct}%;"></span>
+          <span class="perfil-monthly-bar-label">S${index + 1}</span>
+        </div>
+      `;
+    })
+    .join('');
+
+  const heatmapWeekdaysHtml = (monthly.weekdayLabels || [])
+    .map((label) => `<span>${escapeHtml(label)}</span>`)
+    .join('');
+
+  const heatmapCellsHtml = (monthly.heatmapCells || [])
+    .map((cell) => {
+      if (!cell) {
+        return '<div class="perfil-heatmap-day is-empty"></div>';
+      }
+
+      return `
+        <div
+          class="perfil-heatmap-day ${cell.toneClass}"
+          data-heatmap-day="${cell.day}"
+          data-count="${cell.count}"
+          title="Dia ${cell.day}: ${cell.count} rutas"
+          aria-label="Dia ${cell.day}: ${cell.count} rutas"
+        ></div>
+      `;
+    })
+    .join('');
+
+  return `
+    <div class="perfil-stats-card perfil-heatmap-card" data-heatmap-card>
+      <div class="perfil-heatmap-header">
+        <span class="perfil-heatmap-month">${escapeHtml(monthly.monthTitle || '')}</span>
+        <span class="perfil-heatmap-subtitle">${monthly.hasActivity ? 'Mapa de calor' : 'Actividad no disponible en esta version'}</span>
+      </div>
+      <div class="perfil-heatmap-weekdays">
+        ${heatmapWeekdaysHtml}
+      </div>
+      <div class="perfil-heatmap-grid">
+        ${heatmapCellsHtml}
+      </div>
+      <div class="perfil-heatmap-tooltip" role="status" aria-live="polite" data-heatmap-tooltip></div>
+      <div class="perfil-heatmap-legend">
+        <span class="perfil-heatmap-legend-item">
+          <span class="perfil-heatmap-day is-low perfil-heatmap-legend-swatch"></span>
+          <span>1-3 rutas</span>
+        </span>
+        <span class="perfil-heatmap-legend-item">
+          <span class="perfil-heatmap-day is-mid perfil-heatmap-legend-swatch"></span>
+          <span>3-5 rutas</span>
+        </span>
+        <span class="perfil-heatmap-legend-item">
+          <span class="perfil-heatmap-day is-high perfil-heatmap-legend-swatch"></span>
+          <span>5+ rutas</span>
+        </span>
+      </div>
+    </div>
+    <div class="perfil-stats-card perfil-monthly-summary">
+      <div class="perfil-monthly-metrics">
+        <div class="perfil-monthly-metric">
+          <span class="perfil-monthly-label">Rutas del mes</span>
+          <span class="perfil-monthly-value">${monthly.totalMonthlyRoutes || 0}</span>
+        </div>
+        <div class="perfil-monthly-metric">
+          <span class="perfil-monthly-label">Dias activos</span>
+          <span class="perfil-monthly-value">${monthly.activeDays || 0}</span>
+        </div>
+        <div class="perfil-monthly-metric">
+          <span class="perfil-monthly-label">Media por dia</span>
+          <span class="perfil-monthly-value">${toSafePercentage(monthly.avgRoutesPerActiveDay).toFixed(1)}</span>
+        </div>
+      </div>
+      <div class="perfil-monthly-chart" style="grid-template-columns: repeat(${weeklyTotals.length}, minmax(0, 1fr));">
+        ${weeklyBarsHtml}
+      </div>
+    </div>
+  `;
+}
+
+export function bindHeatmapInteractions(container) {
+  const heatmapCard = container.querySelector('[data-heatmap-card]');
+  if (!heatmapCard) {
+    return () => {};
+  }
+
+  const tooltip = heatmapCard.querySelector('[data-heatmap-tooltip]');
+  if (!tooltip) {
+    return () => {};
+  }
+
+  const hideTooltip = () => {
+    tooltip.classList.remove('is-visible');
+  };
+
+  const onHeatmapClick = (event) => {
+    const dayCell = event.target.closest('[data-heatmap-day]');
+
+    if (!dayCell) {
+      hideTooltip();
+      return;
+    }
+
+    const day = dayCell.dataset.heatmapDay;
+    const count = dayCell.dataset.count;
+    tooltip.textContent = `Dia ${day}: ${count} rutas`;
+
+    const cardRect = heatmapCard.getBoundingClientRect();
+    const cellRect = dayCell.getBoundingClientRect();
+    const left = cellRect.left - cardRect.left + cellRect.width / 2;
+    const top = cellRect.top - cardRect.top - 8;
+
+    tooltip.style.left = `${left}px`;
+    tooltip.style.top = `${top}px`;
+    tooltip.classList.add('is-visible');
+  };
+
+  const onDocumentClick = (event) => {
+    if (!heatmapCard.contains(event.target)) {
+      hideTooltip();
+    }
+  };
+
+  heatmapCard.addEventListener('click', onHeatmapClick);
+  document.addEventListener('click', onDocumentClick);
+
+  return () => {
+    heatmapCard.removeEventListener('click', onHeatmapClick);
+    document.removeEventListener('click', onDocumentClick);
+  };
+}

--- a/apps/frontend/src/js/modules/escalador/escaladorController.js
+++ b/apps/frontend/src/js/modules/escalador/escaladorController.js
@@ -5,6 +5,19 @@ import { showToast } from '../../components/toast.js';
 import { showProfilePhotoModal } from '../../components/profilePhotoModal.js';
 
 const PERFIL_PLACEHOLDER = '/assets/johnDoe.png';
+const DEFAULT_ESCALADOR_STATS = {
+    totalRutas: 0,
+    totalFlash: 0,
+    totalCompletado: 0,
+    totalProyecto: 0,
+    porcentajeFlash: 0,
+    totalBloques: 0,
+    totalVias: 0,
+    porcentajeBloques: 0,
+    porcentajeVias: 0,
+    favoritaTexto: 'Bloque',
+    actividadMensual: [],
+};
 let perfilPhotoObjectUrl = null;
 
 function revokeObjectUrl(url) {
@@ -138,11 +151,31 @@ async function cargarPerfilEscalador() {
     return escalador;
 }
 
+async function cargarEstadisticasEscalador() {
+    const [resumenResponse, tiposResponse] = await Promise.all([
+        fetchClient('/escaladores/stats/resumen'),
+        fetchClient('/escaladores/stats/tipos')
+    ]);
+
+    const resumen = await resumenResponse.json();
+    const tipos = await tiposResponse.json();
+
+    return {
+        ...DEFAULT_ESCALADOR_STATS,
+        ...resumen,
+        ...tipos,
+    };
+}
+
 async function renderPerfilConDatos(container, renderFn) {
     showLoading();
 
     try {
-        const escalador = await cargarPerfilEscalador();
+        const [escalador, estadisticas] = await Promise.all([
+            cargarPerfilEscalador(),
+            cargarEstadisticasEscalador().catch(() => DEFAULT_ESCALADOR_STATS)
+        ]);
+        escalador.estadisticas = estadisticas;
 
         const callbacks = {
             onLogout: () => {

--- a/apps/frontend/src/js/modules/escalador/escaladorController.js
+++ b/apps/frontend/src/js/modules/escalador/escaladorController.js
@@ -20,6 +20,66 @@ const DEFAULT_ESCALADOR_STATS = {
 };
 let perfilPhotoObjectUrl = null;
 
+function toSafeNumber(value) {
+    const parsed = Number(value);
+    if (!Number.isFinite(parsed) || parsed < 0) {
+        return 0;
+    }
+
+    return parsed;
+}
+
+function normalizeActividadMensual(actividadMensual) {
+    if (!Array.isArray(actividadMensual)) {
+        return [];
+    }
+
+    return actividadMensual
+        .map((item) => {
+            const dia = Number(item?.dia);
+            const rutas = toSafeNumber(item?.rutas);
+
+            if (!Number.isInteger(dia) || dia < 1 || dia > 31) {
+                return null;
+            }
+
+            return {
+                dia,
+                rutas,
+            };
+        })
+        .filter(Boolean);
+}
+
+function getDefaultEscaladorStats() {
+    return {
+        ...DEFAULT_ESCALADOR_STATS,
+        actividadMensual: [],
+    };
+}
+
+function normalizeEscaladorStats(rawStats = {}) {
+    const favoritaTexto =
+        typeof rawStats.favoritaTexto === 'string' && rawStats.favoritaTexto.trim()
+            ? rawStats.favoritaTexto.trim()
+            : DEFAULT_ESCALADOR_STATS.favoritaTexto;
+
+    return {
+        ...getDefaultEscaladorStats(),
+        totalRutas: toSafeNumber(rawStats.totalRutas),
+        totalFlash: toSafeNumber(rawStats.totalFlash),
+        totalCompletado: toSafeNumber(rawStats.totalCompletado),
+        totalProyecto: toSafeNumber(rawStats.totalProyecto),
+        porcentajeFlash: toSafeNumber(rawStats.porcentajeFlash),
+        totalBloques: toSafeNumber(rawStats.totalBloques),
+        totalVias: toSafeNumber(rawStats.totalVias),
+        porcentajeBloques: toSafeNumber(rawStats.porcentajeBloques),
+        porcentajeVias: toSafeNumber(rawStats.porcentajeVias),
+        favoritaTexto,
+        actividadMensual: normalizeActividadMensual(rawStats.actividadMensual),
+    };
+}
+
 function revokeObjectUrl(url) {
     if (typeof url === 'string' && url.startsWith('blob:')) {
         URL.revokeObjectURL(url);
@@ -171,12 +231,11 @@ async function cargarEstadisticasEscalador() {
         ? actividadPayload.actividadMensual
         : [];
 
-    return {
-        ...DEFAULT_ESCALADOR_STATS,
+    return normalizeEscaladorStats({
         ...resumen,
         ...tipos,
         actividadMensual,
-    };
+    });
 }
 
 async function renderPerfilConDatos(container, renderFn) {
@@ -185,9 +244,9 @@ async function renderPerfilConDatos(container, renderFn) {
     try {
         const [escalador, estadisticas] = await Promise.all([
             cargarPerfilEscalador(),
-            cargarEstadisticasEscalador().catch(() => DEFAULT_ESCALADOR_STATS)
+            cargarEstadisticasEscalador().catch(() => getDefaultEscaladorStats())
         ]);
-        escalador.estadisticas = estadisticas;
+        escalador.estadisticas = normalizeEscaladorStats(estadisticas);
 
         const callbacks = {
             onLogout: () => {

--- a/apps/frontend/src/js/modules/escalador/escaladorController.js
+++ b/apps/frontend/src/js/modules/escalador/escaladorController.js
@@ -152,18 +152,30 @@ async function cargarPerfilEscalador() {
 }
 
 async function cargarEstadisticasEscalador() {
-    const [resumenResponse, tiposResponse] = await Promise.all([
+    const now = new Date();
+    const params = new URLSearchParams({
+        year: String(now.getFullYear()),
+        month: String(now.getMonth() + 1)
+    });
+
+    const [resumenResponse, tiposResponse, actividadResponse] = await Promise.all([
         fetchClient('/escaladores/stats/resumen'),
-        fetchClient('/escaladores/stats/tipos')
+        fetchClient('/escaladores/stats/tipos'),
+        fetchClient(`/escaladores/stats/actividad-mensual?${params.toString()}`)
     ]);
 
     const resumen = await resumenResponse.json();
     const tipos = await tiposResponse.json();
+    const actividadPayload = await actividadResponse.json();
+    const actividadMensual = Array.isArray(actividadPayload?.actividadMensual)
+        ? actividadPayload.actividadMensual
+        : [];
 
     return {
         ...DEFAULT_ESCALADOR_STATS,
         ...resumen,
         ...tipos,
+        actividadMensual,
     };
 }
 

--- a/apps/frontend/src/js/modules/escalador/escaladorView.js
+++ b/apps/frontend/src/js/modules/escalador/escaladorView.js
@@ -19,6 +19,15 @@ export function renderPerfil(container, escalador, callbacks) {
     descripcionLimpia && descripcionLimpia.toLowerCase() !== 'null'
       ? escapeHtml(descripcionLimpia)
       : '';
+  const totalRutas = 18;
+  const totalFlash = 5;
+  const totalBloques = 8;
+  const totalVias = 10;
+  const rutasFlashPct = totalRutas > 0 ? (totalFlash / totalRutas) * 100 : 0;
+  const bloquesPct = totalRutas > 0 ? (totalBloques / totalRutas) * 100 : 0;
+  const viasPct = totalRutas > 0 ? (totalVias / totalRutas) * 100 : 0;
+  const favoritaTexto = totalBloques >= totalVias ? 'Bloque' : 'Via';
+  const formatPct = (value) => `${value.toFixed(2)}%`;
 
   container.innerHTML = `
       <!-- Cabecera -->
@@ -97,8 +106,57 @@ export function renderPerfil(container, escalador, callbacks) {
 
           <div class="perfil-estadisticas-wrap mt-4">
             ${renderSectionDivider({ label: 'Estadisticas' })}
-            <div class="perfil-estadisticas-view text-center text-muted small mt-3">
-              Sin estadisticas por ahora.
+            <div class="perfil-estadisticas-view mt-3">
+              <div class="perfil-stats-section">
+                <p class="perfil-stats-title">Total de Rutas Escaladas</p>
+                <div class="perfil-stats-card">
+                  <div class="perfil-stats-badges">
+                    <div class="perfil-stats-badge is-completed">
+                      <span class="perfil-stats-badge-value">${totalRutas}</span>
+                      <span class="perfil-stats-badge-label">Completado</span>
+                    </div>
+                    <div class="perfil-stats-badge is-flash">
+                      <span class="perfil-stats-badge-value">${totalFlash}</span>
+                      <span class="perfil-stats-badge-label">Flash</span>
+                    </div>
+                  </div>
+                  <p class="perfil-stats-text">
+                    Has escalado un total de ${totalRutas} rutas, de las cuales ${totalFlash} han sido a la primera.
+                  </p>
+                  <div class="perfil-stats-bar">
+                    <span class="perfil-stats-bar-fill is-completed" style="width: 100%;"></span>
+                    <span class="perfil-stats-bar-fill is-flash" style="width: ${formatPct(rutasFlashPct)};"></span>
+                  </div>
+                  <div class="perfil-stats-bar-labels">
+                    <span>${formatPct(rutasFlashPct)}</span>
+                  </div>
+                </div>
+              </div>
+
+              <div class="perfil-stats-section">
+                <p class="perfil-stats-title">Tipos de Rutas Escaladas</p>
+                <div class="perfil-stats-card">
+                  <div class="perfil-stats-choices">
+                    <div class="perfil-stats-pill is-bloque">
+                      <span class="perfil-stats-pill-label">Bloques</span>
+                      <span class="perfil-stats-pill-value">${totalBloques}</span>
+                    </div>
+                    <div class="perfil-stats-pill is-via">
+                      <span class="perfil-stats-pill-label">Vias</span>
+                      <span class="perfil-stats-pill-value">${totalVias}</span>
+                    </div>
+                  </div>
+                  <p class="perfil-stats-text">Tu tipo de ruta favorita es el ${favoritaTexto}.</p>
+                  <div class="perfil-stats-bar is-split">
+                    <span class="perfil-stats-bar-fill is-bloque" style="width: ${formatPct(bloquesPct)};"></span>
+                    <span class="perfil-stats-bar-fill is-via" style="width: ${formatPct(viasPct)};"></span>
+                  </div>
+                  <div class="perfil-stats-bar-labels">
+                    <span>${formatPct(bloquesPct)}</span>
+                    <span>${formatPct(viasPct)}</span>
+                  </div>
+                </div>
+              </div>
             </div>
           </div>
         </div>

--- a/apps/frontend/src/js/modules/escalador/escaladorView.js
+++ b/apps/frontend/src/js/modules/escalador/escaladorView.js
@@ -10,7 +10,7 @@ function renderPerfilFieldTitle(text) {
 
 // Vista del perfil del escalador
 export function renderPerfil(container, escalador, callbacks) {
-  const { apodo, descripcion, fotoSrc } = escalador;
+  const { apodo, descripcion, fotoSrc, estadisticas = {} } = escalador;
   const avatar = fotoSrc || '/assets/johnDoe.png';
   const apodoLimpio = typeof apodo === 'string' ? apodo.trim() : '';
   const descripcionLimpia =
@@ -19,14 +19,19 @@ export function renderPerfil(container, escalador, callbacks) {
     descripcionLimpia && descripcionLimpia.toLowerCase() !== 'null'
       ? escapeHtml(descripcionLimpia)
       : '';
-  const totalRutas = 18;
-  const totalFlash = 5;
-  const totalBloques = 8;
-  const totalVias = 10;
+  const totalRutas = Number(estadisticas.totalRutas) || 0;
+  const totalFlash = Number(estadisticas.totalFlash) || 0;
+  const totalBloques = Number(estadisticas.totalBloques) || 0;
+  const totalVias = Number(estadisticas.totalVias) || 0;
   const rutasFlashPct = totalRutas > 0 ? (totalFlash / totalRutas) * 100 : 0;
   const bloquesPct = totalRutas > 0 ? (totalBloques / totalRutas) * 100 : 0;
   const viasPct = totalRutas > 0 ? (totalVias / totalRutas) * 100 : 0;
-  const favoritaTexto = totalBloques >= totalVias ? 'Bloque' : 'Via';
+  const favoritaTexto =
+    typeof estadisticas.favoritaTexto === 'string' && estadisticas.favoritaTexto.trim()
+      ? estadisticas.favoritaTexto.trim()
+      : totalBloques >= totalVias
+        ? 'Bloque'
+        : 'Via';
   const formatPct = (value) => `${value.toFixed(2)}%`;
   const now = new Date();
   const currentYear = now.getFullYear();
@@ -42,12 +47,17 @@ export function renderPerfil(container, escalador, callbacks) {
   const totalHeatmapCells =
     Math.ceil((firstDayIndex + daysInMonth) / 7) * 7;
   const weekdayLabels = ['L', 'M', 'X', 'J', 'V', 'S', 'D'];
-  const baseSeed = currentYear * 10000 + (currentMonth + 1) * 100;
-  const getHeatmapCount = (day) => {
-    const seed = baseSeed + day;
-    const raw = (seed * 9301 + 49297) % 233280;
-    return Math.floor((raw / 233280) * 7);
-  };
+  const actividadMensual = Array.isArray(estadisticas.actividadMensual)
+    ? estadisticas.actividadMensual
+    : [];
+  const actividadPorDia = actividadMensual.reduce((acc, item) => {
+    const dia = Number(item?.dia);
+    const rutas = Number(item?.rutas);
+    if (Number.isInteger(dia) && dia > 0 && dia <= daysInMonth) {
+      acc[dia] = Number.isFinite(rutas) && rutas > 0 ? rutas : 0;
+    }
+    return acc;
+  }, {});
   const heatmapCells = Array.from({ length: totalHeatmapCells }, (_, index) => {
     const dayNumber = index - firstDayIndex + 1;
 
@@ -57,7 +67,7 @@ export function renderPerfil(container, escalador, callbacks) {
 
     return {
       day: dayNumber,
-      count: getHeatmapCount(dayNumber),
+      count: actividadPorDia[dayNumber] || 0,
     };
   });
   const heatmapCounts = heatmapCells.map((cell) => (cell ? cell.count : 0));
@@ -253,7 +263,7 @@ export function renderPerfil(container, escalador, callbacks) {
                 <div class="perfil-stats-card perfil-heatmap-card">
                   <div class="perfil-heatmap-header">
                     <span class="perfil-heatmap-month">${monthTitle}</span>
-                    <span class="perfil-heatmap-subtitle">Mapa de calor</span>
+                    <span class="perfil-heatmap-subtitle">${actividadMensual.length ? 'Mapa de calor' : 'Actividad no disponible en esta version'}</span>
                   </div>
                   <div class="perfil-heatmap-weekdays">
                     ${heatmapWeekdaysHtml}

--- a/apps/frontend/src/js/modules/escalador/escaladorView.js
+++ b/apps/frontend/src/js/modules/escalador/escaladorView.js
@@ -28,6 +28,67 @@ export function renderPerfil(container, escalador, callbacks) {
   const viasPct = totalRutas > 0 ? (totalVias / totalRutas) * 100 : 0;
   const favoritaTexto = totalBloques >= totalVias ? 'Bloque' : 'Via';
   const formatPct = (value) => `${value.toFixed(2)}%`;
+  const now = new Date();
+  const currentYear = now.getFullYear();
+  const currentMonth = now.getMonth();
+  const monthLabel = now.toLocaleString('es-ES', {
+    month: 'long',
+    year: 'numeric',
+  });
+  const monthTitle =
+    monthLabel.charAt(0).toUpperCase() + monthLabel.slice(1);
+  const daysInMonth = new Date(currentYear, currentMonth + 1, 0).getDate();
+  const firstDayIndex = (new Date(currentYear, currentMonth, 1).getDay() + 6) % 7;
+  const totalHeatmapCells =
+    Math.ceil((firstDayIndex + daysInMonth) / 7) * 7;
+  const weekdayLabels = ['L', 'M', 'X', 'J', 'V', 'S', 'D'];
+  const baseSeed = currentYear * 10000 + (currentMonth + 1) * 100;
+  const getHeatmapCount = (day) => {
+    const seed = baseSeed + day;
+    const raw = (seed * 9301 + 49297) % 233280;
+    return Math.floor((raw / 233280) * 7);
+  };
+  const heatmapCells = Array.from({ length: totalHeatmapCells }, (_, index) => {
+    const dayNumber = index - firstDayIndex + 1;
+
+    if (dayNumber < 1 || dayNumber > daysInMonth) {
+      return null;
+    }
+
+    return {
+      day: dayNumber,
+      count: getHeatmapCount(dayNumber),
+    };
+  });
+  const heatmapWeekdaysHtml = weekdayLabels
+    .map((label) => `<span>${label}</span>`)
+    .join('');
+  const heatmapCellsHtml = heatmapCells
+    .map((cell) => {
+      if (!cell) {
+        return '<div class="perfil-heatmap-day is-empty"></div>';
+      }
+
+      let toneClass = 'is-zero';
+      if (cell.count >= 5) {
+        toneClass = 'is-high';
+      } else if (cell.count >= 3) {
+        toneClass = 'is-mid';
+      } else if (cell.count >= 1) {
+        toneClass = 'is-low';
+      }
+
+      return `
+        <div
+          class="perfil-heatmap-day ${toneClass}"
+          data-day="${cell.day}"
+          data-count="${cell.count}"
+          title="Dia ${cell.day}: ${cell.count} rutas"
+          aria-label="Dia ${cell.day}: ${cell.count} rutas"
+        ></div>
+      `;
+    })
+    .join('');
 
   container.innerHTML = `
       <!-- Cabecera -->
@@ -157,6 +218,33 @@ export function renderPerfil(container, escalador, callbacks) {
                   </div>
                 </div>
               </div>
+
+              <div class="perfil-stats-section">
+                <p class="perfil-stats-title">${monthTitle}</p>
+                <div class="perfil-stats-card perfil-heatmap-card">
+                  <div class="perfil-heatmap-weekdays">
+                    ${heatmapWeekdaysHtml}
+                  </div>
+                  <div class="perfil-heatmap-grid">
+                    ${heatmapCellsHtml}
+                  </div>
+                  <div class="perfil-heatmap-tooltip" role="status" aria-live="polite"></div>
+                  <div class="perfil-heatmap-legend">
+                    <span class="perfil-heatmap-legend-item">
+                      <span class="perfil-heatmap-day is-low perfil-heatmap-legend-swatch"></span>
+                      <span>1-3 rutas</span>
+                    </span>
+                    <span class="perfil-heatmap-legend-item">
+                      <span class="perfil-heatmap-day is-mid perfil-heatmap-legend-swatch"></span>
+                      <span>3-5 rutas</span>
+                    </span>
+                    <span class="perfil-heatmap-legend-item">
+                      <span class="perfil-heatmap-day is-high perfil-heatmap-legend-swatch"></span>
+                      <span>5+ rutas</span>
+                    </span>
+                  </div>
+                </div>
+              </div>
             </div>
           </div>
         </div>
@@ -165,6 +253,32 @@ export function renderPerfil(container, escalador, callbacks) {
       <!-- Menú de navegación inferior -->
       ${renderNavbar()}
     `;
+
+  const heatmapCard = container.querySelector('.perfil-heatmap-card');
+  if (heatmapCard) {
+    const tooltip = heatmapCard.querySelector('.perfil-heatmap-tooltip');
+    heatmapCard.addEventListener('click', (event) => {
+      const dayCell = event.target.closest('.perfil-heatmap-day[data-day]');
+
+      if (!dayCell) {
+        tooltip.classList.remove('is-visible');
+        return;
+      }
+
+      const day = dayCell.dataset.day;
+      const count = dayCell.dataset.count;
+      tooltip.textContent = `Dia ${day}: ${count} rutas`;
+
+      const cardRect = heatmapCard.getBoundingClientRect();
+      const cellRect = dayCell.getBoundingClientRect();
+      const left = cellRect.left - cardRect.left + cellRect.width / 2;
+      const top = cellRect.top - cardRect.top - 8;
+
+      tooltip.style.left = `${left}px`;
+      tooltip.style.top = `${top}px`;
+      tooltip.classList.add('is-visible');
+    });
+  }
 
   const menuPlaceholders = container.querySelectorAll(
     '[data-menu-placeholder]'

--- a/apps/frontend/src/js/modules/escalador/escaladorView.js
+++ b/apps/frontend/src/js/modules/escalador/escaladorView.js
@@ -60,6 +60,35 @@ export function renderPerfil(container, escalador, callbacks) {
       count: getHeatmapCount(dayNumber),
     };
   });
+  const heatmapCounts = heatmapCells.map((cell) => (cell ? cell.count : 0));
+  const totalMonthlyRoutes = heatmapCounts.reduce(
+    (acc, count) => acc + count,
+    0
+  );
+  const activeDays = heatmapCells.filter(
+    (cell) => cell && cell.count > 0
+  ).length;
+  const avgRoutesPerActiveDay = activeDays
+    ? totalMonthlyRoutes / activeDays
+    : 0;
+  const weeklyTotals = [];
+  for (let i = 0; i < heatmapCounts.length; i += 7) {
+    weeklyTotals.push(
+      heatmapCounts.slice(i, i + 7).reduce((acc, count) => acc + count, 0)
+    );
+  }
+  const maxWeeklyTotal = Math.max(1, ...weeklyTotals);
+  const weeklyBarsHtml = weeklyTotals
+    .map((total, index) => {
+      const heightPct = (total / maxWeeklyTotal) * 100;
+      return `
+        <div class="perfil-monthly-bar">
+          <span class="perfil-monthly-bar-fill" style="height: ${heightPct}%;"></span>
+          <span class="perfil-monthly-bar-label">S${index + 1}</span>
+        </div>
+      `;
+    })
+    .join('');
   const heatmapWeekdaysHtml = weekdayLabels
     .map((label) => `<span>${label}</span>`)
     .join('');
@@ -220,8 +249,12 @@ export function renderPerfil(container, escalador, callbacks) {
               </div>
 
               <div class="perfil-stats-section">
-                <p class="perfil-stats-title">${monthTitle}</p>
+                <p class="perfil-stats-title">Actividad mensual</p>
                 <div class="perfil-stats-card perfil-heatmap-card">
+                  <div class="perfil-heatmap-header">
+                    <span class="perfil-heatmap-month">${monthTitle}</span>
+                    <span class="perfil-heatmap-subtitle">Mapa de calor</span>
+                  </div>
                   <div class="perfil-heatmap-weekdays">
                     ${heatmapWeekdaysHtml}
                   </div>
@@ -242,6 +275,25 @@ export function renderPerfil(container, escalador, callbacks) {
                       <span class="perfil-heatmap-day is-high perfil-heatmap-legend-swatch"></span>
                       <span>5+ rutas</span>
                     </span>
+                  </div>
+                </div>
+                <div class="perfil-stats-card perfil-monthly-summary">
+                  <div class="perfil-monthly-metrics">
+                    <div class="perfil-monthly-metric">
+                      <span class="perfil-monthly-label">Rutas del mes</span>
+                      <span class="perfil-monthly-value">${totalMonthlyRoutes}</span>
+                    </div>
+                    <div class="perfil-monthly-metric">
+                      <span class="perfil-monthly-label">Dias activos</span>
+                      <span class="perfil-monthly-value">${activeDays}</span>
+                    </div>
+                    <div class="perfil-monthly-metric">
+                      <span class="perfil-monthly-label">Media por dia</span>
+                      <span class="perfil-monthly-value">${avgRoutesPerActiveDay.toFixed(1)}</span>
+                    </div>
+                  </div>
+                  <div class="perfil-monthly-chart" style="grid-template-columns: repeat(${weeklyTotals.length}, minmax(0, 1fr));">
+                    ${weeklyBarsHtml}
                   </div>
                 </div>
               </div>

--- a/apps/frontend/src/js/modules/escalador/escaladorView.js
+++ b/apps/frontend/src/js/modules/escalador/escaladorView.js
@@ -3,14 +3,49 @@ import { showConfirmModal } from '../../components/modal.js';
 import { escapeHtml } from '../../components/formHelpers.js';
 import { renderEditableField, initEditableField } from '../../components/editableField.js';
 import { renderSectionDivider } from '../../components/sectionDivider.js';
+import {
+  bindHeatmapInteractions,
+  buildEscaladorStatsViewModel,
+  renderMonthlyActivityCards,
+  renderRouteTypesStatsCard,
+  renderStatsSection,
+  renderTotalRoutesStatsCard,
+} from '../../components/escaladorStats.js';
 
 function renderPerfilFieldTitle(text) {
   return `<p class="text-muted small text-uppercase fw-semibold mb-1 perfil-field-title">${text}</p>`;
 }
 
+function renderPerfilStats(statsViewModel) {
+  return `
+    <div class="perfil-estadisticas-wrap mt-4">
+      ${renderSectionDivider({ label: 'Estadisticas' })}
+      <div class="perfil-estadisticas-view mt-3">
+        ${renderStatsSection({
+          title: 'Total de Rutas Escaladas',
+          content: renderTotalRoutesStatsCard(statsViewModel.totals),
+        })}
+        ${renderStatsSection({
+          title: 'Tipos de Rutas Escaladas',
+          content: renderRouteTypesStatsCard(statsViewModel.totals),
+        })}
+        ${renderStatsSection({
+          title: 'Actividad mensual',
+          content: renderMonthlyActivityCards(statsViewModel.monthly),
+        })}
+      </div>
+    </div>
+  `;
+}
+
 // Vista del perfil del escalador
 export function renderPerfil(container, escalador, callbacks) {
   const { apodo, descripcion, fotoSrc, estadisticas = {} } = escalador;
+  if (typeof container.__perfilStatsCleanup === 'function') {
+    container.__perfilStatsCleanup();
+    container.__perfilStatsCleanup = null;
+  }
+
   const avatar = fotoSrc || '/assets/johnDoe.png';
   const apodoLimpio = typeof apodo === 'string' ? apodo.trim() : '';
   const descripcionLimpia =
@@ -19,115 +54,7 @@ export function renderPerfil(container, escalador, callbacks) {
     descripcionLimpia && descripcionLimpia.toLowerCase() !== 'null'
       ? escapeHtml(descripcionLimpia)
       : '';
-  const totalRutas = Number(estadisticas.totalRutas) || 0;
-  const totalFlash = Number(estadisticas.totalFlash) || 0;
-  const totalBloques = Number(estadisticas.totalBloques) || 0;
-  const totalVias = Number(estadisticas.totalVias) || 0;
-  const rutasFlashPct = totalRutas > 0 ? (totalFlash / totalRutas) * 100 : 0;
-  const bloquesPct = totalRutas > 0 ? (totalBloques / totalRutas) * 100 : 0;
-  const viasPct = totalRutas > 0 ? (totalVias / totalRutas) * 100 : 0;
-  const favoritaTexto =
-    typeof estadisticas.favoritaTexto === 'string' && estadisticas.favoritaTexto.trim()
-      ? estadisticas.favoritaTexto.trim()
-      : totalBloques >= totalVias
-        ? 'Bloque'
-        : 'Via';
-  const formatPct = (value) => `${value.toFixed(2)}%`;
-  const now = new Date();
-  const currentYear = now.getFullYear();
-  const currentMonth = now.getMonth();
-  const monthLabel = now.toLocaleString('es-ES', {
-    month: 'long',
-    year: 'numeric',
-  });
-  const monthTitle =
-    monthLabel.charAt(0).toUpperCase() + monthLabel.slice(1);
-  const daysInMonth = new Date(currentYear, currentMonth + 1, 0).getDate();
-  const firstDayIndex = (new Date(currentYear, currentMonth, 1).getDay() + 6) % 7;
-  const totalHeatmapCells =
-    Math.ceil((firstDayIndex + daysInMonth) / 7) * 7;
-  const weekdayLabels = ['L', 'M', 'X', 'J', 'V', 'S', 'D'];
-  const actividadMensual = Array.isArray(estadisticas.actividadMensual)
-    ? estadisticas.actividadMensual
-    : [];
-  const actividadPorDia = actividadMensual.reduce((acc, item) => {
-    const dia = Number(item?.dia);
-    const rutas = Number(item?.rutas);
-    if (Number.isInteger(dia) && dia > 0 && dia <= daysInMonth) {
-      acc[dia] = Number.isFinite(rutas) && rutas > 0 ? rutas : 0;
-    }
-    return acc;
-  }, {});
-  const heatmapCells = Array.from({ length: totalHeatmapCells }, (_, index) => {
-    const dayNumber = index - firstDayIndex + 1;
-
-    if (dayNumber < 1 || dayNumber > daysInMonth) {
-      return null;
-    }
-
-    return {
-      day: dayNumber,
-      count: actividadPorDia[dayNumber] || 0,
-    };
-  });
-  const heatmapCounts = heatmapCells.map((cell) => (cell ? cell.count : 0));
-  const totalMonthlyRoutes = heatmapCounts.reduce(
-    (acc, count) => acc + count,
-    0
-  );
-  const activeDays = heatmapCells.filter(
-    (cell) => cell && cell.count > 0
-  ).length;
-  const avgRoutesPerActiveDay = activeDays
-    ? totalMonthlyRoutes / activeDays
-    : 0;
-  const weeklyTotals = [];
-  for (let i = 0; i < heatmapCounts.length; i += 7) {
-    weeklyTotals.push(
-      heatmapCounts.slice(i, i + 7).reduce((acc, count) => acc + count, 0)
-    );
-  }
-  const maxWeeklyTotal = Math.max(1, ...weeklyTotals);
-  const weeklyBarsHtml = weeklyTotals
-    .map((total, index) => {
-      const heightPct = (total / maxWeeklyTotal) * 100;
-      return `
-        <div class="perfil-monthly-bar">
-          <span class="perfil-monthly-bar-fill" style="height: ${heightPct}%;"></span>
-          <span class="perfil-monthly-bar-label">S${index + 1}</span>
-        </div>
-      `;
-    })
-    .join('');
-  const heatmapWeekdaysHtml = weekdayLabels
-    .map((label) => `<span>${label}</span>`)
-    .join('');
-  const heatmapCellsHtml = heatmapCells
-    .map((cell) => {
-      if (!cell) {
-        return '<div class="perfil-heatmap-day is-empty"></div>';
-      }
-
-      let toneClass = 'is-zero';
-      if (cell.count >= 5) {
-        toneClass = 'is-high';
-      } else if (cell.count >= 3) {
-        toneClass = 'is-mid';
-      } else if (cell.count >= 1) {
-        toneClass = 'is-low';
-      }
-
-      return `
-        <div
-          class="perfil-heatmap-day ${toneClass}"
-          data-day="${cell.day}"
-          data-count="${cell.count}"
-          title="Dia ${cell.day}: ${cell.count} rutas"
-          aria-label="Dia ${cell.day}: ${cell.count} rutas"
-        ></div>
-      `;
-    })
-    .join('');
+  const statsViewModel = buildEscaladorStatsViewModel(estadisticas);
 
   container.innerHTML = `
       <!-- Cabecera -->
@@ -204,111 +131,7 @@ export function renderPerfil(container, escalador, callbacks) {
             </div>
           </div>
 
-          <div class="perfil-estadisticas-wrap mt-4">
-            ${renderSectionDivider({ label: 'Estadisticas' })}
-            <div class="perfil-estadisticas-view mt-3">
-              <div class="perfil-stats-section">
-                <p class="perfil-stats-title">Total de Rutas Escaladas</p>
-                <div class="perfil-stats-card">
-                  <div class="perfil-stats-badges">
-                    <div class="perfil-stats-badge is-completed">
-                      <span class="perfil-stats-badge-value">${totalRutas}</span>
-                      <span class="perfil-stats-badge-label">Completado</span>
-                    </div>
-                    <div class="perfil-stats-badge is-flash">
-                      <span class="perfil-stats-badge-value">${totalFlash}</span>
-                      <span class="perfil-stats-badge-label">Flash</span>
-                    </div>
-                  </div>
-                  <p class="perfil-stats-text">
-                    Has escalado un total de ${totalRutas} rutas, de las cuales ${totalFlash} han sido a la primera.
-                  </p>
-                  <div class="perfil-stats-bar">
-                    <span class="perfil-stats-bar-fill is-completed" style="width: 100%;"></span>
-                    <span class="perfil-stats-bar-fill is-flash" style="width: ${formatPct(rutasFlashPct)};"></span>
-                  </div>
-                  <div class="perfil-stats-bar-labels">
-                    <span>${formatPct(rutasFlashPct)}</span>
-                  </div>
-                </div>
-              </div>
-
-              <div class="perfil-stats-section">
-                <p class="perfil-stats-title">Tipos de Rutas Escaladas</p>
-                <div class="perfil-stats-card">
-                  <div class="perfil-stats-choices">
-                    <div class="perfil-stats-pill is-bloque">
-                      <span class="perfil-stats-pill-label">Bloques</span>
-                      <span class="perfil-stats-pill-value">${totalBloques}</span>
-                    </div>
-                    <div class="perfil-stats-pill is-via">
-                      <span class="perfil-stats-pill-label">Vias</span>
-                      <span class="perfil-stats-pill-value">${totalVias}</span>
-                    </div>
-                  </div>
-                  <p class="perfil-stats-text">Tu tipo de ruta favorita es el ${favoritaTexto}.</p>
-                  <div class="perfil-stats-bar is-split">
-                    <span class="perfil-stats-bar-fill is-bloque" style="width: ${formatPct(bloquesPct)};"></span>
-                    <span class="perfil-stats-bar-fill is-via" style="width: ${formatPct(viasPct)};"></span>
-                  </div>
-                  <div class="perfil-stats-bar-labels">
-                    <span>${formatPct(bloquesPct)}</span>
-                    <span>${formatPct(viasPct)}</span>
-                  </div>
-                </div>
-              </div>
-
-              <div class="perfil-stats-section">
-                <p class="perfil-stats-title">Actividad mensual</p>
-                <div class="perfil-stats-card perfil-heatmap-card">
-                  <div class="perfil-heatmap-header">
-                    <span class="perfil-heatmap-month">${monthTitle}</span>
-                    <span class="perfil-heatmap-subtitle">${actividadMensual.length ? 'Mapa de calor' : 'Actividad no disponible en esta version'}</span>
-                  </div>
-                  <div class="perfil-heatmap-weekdays">
-                    ${heatmapWeekdaysHtml}
-                  </div>
-                  <div class="perfil-heatmap-grid">
-                    ${heatmapCellsHtml}
-                  </div>
-                  <div class="perfil-heatmap-tooltip" role="status" aria-live="polite"></div>
-                  <div class="perfil-heatmap-legend">
-                    <span class="perfil-heatmap-legend-item">
-                      <span class="perfil-heatmap-day is-low perfil-heatmap-legend-swatch"></span>
-                      <span>1-3 rutas</span>
-                    </span>
-                    <span class="perfil-heatmap-legend-item">
-                      <span class="perfil-heatmap-day is-mid perfil-heatmap-legend-swatch"></span>
-                      <span>3-5 rutas</span>
-                    </span>
-                    <span class="perfil-heatmap-legend-item">
-                      <span class="perfil-heatmap-day is-high perfil-heatmap-legend-swatch"></span>
-                      <span>5+ rutas</span>
-                    </span>
-                  </div>
-                </div>
-                <div class="perfil-stats-card perfil-monthly-summary">
-                  <div class="perfil-monthly-metrics">
-                    <div class="perfil-monthly-metric">
-                      <span class="perfil-monthly-label">Rutas del mes</span>
-                      <span class="perfil-monthly-value">${totalMonthlyRoutes}</span>
-                    </div>
-                    <div class="perfil-monthly-metric">
-                      <span class="perfil-monthly-label">Dias activos</span>
-                      <span class="perfil-monthly-value">${activeDays}</span>
-                    </div>
-                    <div class="perfil-monthly-metric">
-                      <span class="perfil-monthly-label">Media por dia</span>
-                      <span class="perfil-monthly-value">${avgRoutesPerActiveDay.toFixed(1)}</span>
-                    </div>
-                  </div>
-                  <div class="perfil-monthly-chart" style="grid-template-columns: repeat(${weeklyTotals.length}, minmax(0, 1fr));">
-                    ${weeklyBarsHtml}
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
+          ${renderPerfilStats(statsViewModel)}
         </div>
       </div>
 
@@ -316,31 +139,7 @@ export function renderPerfil(container, escalador, callbacks) {
       ${renderNavbar()}
     `;
 
-  const heatmapCard = container.querySelector('.perfil-heatmap-card');
-  if (heatmapCard) {
-    const tooltip = heatmapCard.querySelector('.perfil-heatmap-tooltip');
-    heatmapCard.addEventListener('click', (event) => {
-      const dayCell = event.target.closest('.perfil-heatmap-day[data-day]');
-
-      if (!dayCell) {
-        tooltip.classList.remove('is-visible');
-        return;
-      }
-
-      const day = dayCell.dataset.day;
-      const count = dayCell.dataset.count;
-      tooltip.textContent = `Dia ${day}: ${count} rutas`;
-
-      const cardRect = heatmapCard.getBoundingClientRect();
-      const cellRect = dayCell.getBoundingClientRect();
-      const left = cellRect.left - cardRect.left + cellRect.width / 2;
-      const top = cellRect.top - cardRect.top - 8;
-
-      tooltip.style.left = `${left}px`;
-      tooltip.style.top = `${top}px`;
-      tooltip.classList.add('is-visible');
-    });
-  }
+  container.__perfilStatsCleanup = bindHeatmapInteractions(container);
 
   const menuPlaceholders = container.querySelectorAll(
     '[data-menu-placeholder]'
@@ -372,6 +171,11 @@ export function renderPerfil(container, escalador, callbacks) {
 
 // Vista de editar perfil
 export function renderEditarPerfil(container, escalador, callbacks) {
+  if (typeof container.__perfilStatsCleanup === 'function') {
+    container.__perfilStatsCleanup();
+    container.__perfilStatsCleanup = null;
+  }
+
   const { apodo, descripcion, fotoSrc, correo } = escalador;
   const avatar = fotoSrc || '/assets/johnDoe.png';
   const apodoLimpio = typeof apodo === 'string' ? apodo.trim() : '';


### PR DESCRIPTION
Backend:
1. Se crearon endpoints de estadísticas para resumen, tipos de rutas y actividad mensual (autenticado y público por apodo).
2. Se implementaron casos de uso y lógica de repositorio para calcular esas métricas.
3. Se dejó de calcular actividad mensual usando fecha de creación de pista.
4. Se añadió en EscalaPista un campo de fecha de completado.
5. Se creó migración con backfill para que registros existentes en estado flash/completado tengan fecha (si no hay fecha previa, usa la actual).
6. Al cambiar estado de pista:
- flash/completado: se guarda fecha de completado actual.
-  proyecto: la fecha de completado queda en null.
7. La actividad mensual ahora se calcula con fecha de completado real y devuelve también esa fecha en el payload.
8. El frontend carga dinámicamente resumen, tipos y actividad mensual para alimentar heatmap y cards.
9. Se reforzaron, ajustaron y crearon tests para validar los cambios.

Frontend:

1. Se añadieron nuevas secciones de estadísticas en el perfil con valores placeholder, cálculo de porcentajes y barras de progreso.
2. Se incorporó un mapa de calor mensual con leyenda de colores y tooltip al pulsar un día.
3. Se agregó una tarjeta de resumen mensual con métricas y un gráfico de barras por semanas, ajustando el número de columnas según el mes.
4. Separación de las estadísticas a un componente