### PR TITLE
fix: Dynamic viewport height (dvh)

### DIFF
--- a/apps/frontend/src/js/app.js
+++ b/apps/frontend/src/js/app.js
@@ -5,6 +5,9 @@ import { initConnectivityBanner } from './core/ui.js';
 registerSW({ immediate: true });
 
 function updateViewportHeightVariable() {
+	const tag = document.activeElement?.tagName;
+	if (tag === 'INPUT' || tag === 'TEXTAREA') return;
+
 	const viewportHeight = window.visualViewport?.height || window.innerHeight;
 	document.documentElement.style.setProperty('--vh', `${viewportHeight * 0.01}px`);
 }


### PR DESCRIPTION
Prevenir la actualización del dynamic viewport height (dvh) cuando se despliega el teclado del movil para evitar el desplazamiento de la navbar